### PR TITLE
Add debug command and toggle functionality

### DIFF
--- a/plugin/.gradle/buildOutputCleanup/cache.properties
+++ b/plugin/.gradle/buildOutputCleanup/cache.properties
@@ -1,2 +1,2 @@
-#Fri Jul 25 19:21:21 UTC 2025
+#Mon Jul 28 17:19:11 UTC 2025
 gradle.version=8.11

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/SuperSmashMobsBrawl.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/SuperSmashMobsBrawl.kt
@@ -1,11 +1,13 @@
 package dev.betrix.superSmashMobsBrawl
 
 import com.github.shynixn.mccoroutine.bukkit.SuspendingJavaPlugin
+import dev.betrix.superSmashMobsBrawl.commands.DebugCommand
 import dev.betrix.superSmashMobsBrawl.commands.KitCommand
 import dev.betrix.superSmashMobsBrawl.commands.LeaveCommand
 import dev.betrix.superSmashMobsBrawl.commands.QueueCommand
 import dev.betrix.superSmashMobsBrawl.commands.argumentResolvers.MinigameDefinitionArgument
 import dev.betrix.superSmashMobsBrawl.minigames.definitions.MinigameDefinition
+import dev.betrix.superSmashMobsBrawl.services.DebugService
 import dev.betrix.superSmashMobsBrawl.services.HotbarService
 import dev.betrix.superSmashMobsBrawl.services.HubProtectionService
 import dev.betrix.superSmashMobsBrawl.services.HubService
@@ -37,6 +39,7 @@ class SuperSmashMobsBrawl : SuspendingJavaPlugin() {
         HotbarService.initialize(this)
         HubService.initialize(this)
         HubProtectionService.registerEvents()
+        DebugService.initialize(this)
 
         liteCommands =
             LiteBukkitFactory.builder(this)
@@ -44,6 +47,7 @@ class SuperSmashMobsBrawl : SuspendingJavaPlugin() {
                 .commands(QueueCommand())
                 .commands(KitCommand())
                 .commands(LeaveCommand())
+                .commands(DebugCommand())
                 .build()
 
         // Player join events are now handled by HubService
@@ -66,6 +70,7 @@ class SuperSmashMobsBrawl : SuspendingJavaPlugin() {
     override suspend fun onDisableAsync() {
         HubService.teardown()
         WorldService.teardown()
+        DebugService.teardown()
         logger.info("SSMB shutting down")
     }
 }

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/commands/DebugCommand.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/commands/DebugCommand.kt
@@ -1,0 +1,39 @@
+package dev.betrix.superSmashMobsBrawl.commands
+
+import dev.betrix.superSmashMobsBrawl.services.DebugService
+import dev.betrix.superSmashMobsBrawl.utils.ONLY_PLAYERS_EXEC_MESSAGE
+import dev.betrix.superSmashMobsBrawl.utils.mm
+import dev.rollczi.litecommands.annotations.command.Command
+import dev.rollczi.litecommands.annotations.context.Context
+import dev.rollczi.litecommands.annotations.execute.Execute
+import org.bukkit.command.CommandSender
+import org.bukkit.entity.Player
+
+@Command(name = "debug")
+class DebugCommand {
+
+    @Execute
+    fun debug(@Context sender: CommandSender) {
+        if (sender !is Player) {
+            sender.sendMessage(ONLY_PLAYERS_EXEC_MESSAGE)
+            return
+        }
+
+        // Check permission
+        if (!sender.hasPermission("ssmb.debug")) {
+            sender.sendMessage(mm("<red>You don't have permission to use this command!</red>"))
+            return
+        }
+
+        // Toggle debug mode
+        val debugEnabled = DebugService.toggleDebug(sender)
+        
+        val message = if (debugEnabled) {
+            mm("<green>Debug mode enabled! You will now see debug information.</green>")
+        } else {
+            mm("<yellow>Debug mode disabled. Debug information will no longer be shown.</yellow>")
+        }
+        
+        sender.sendMessage(message)
+    }
+}

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/commands/QueueCommand.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/commands/QueueCommand.kt
@@ -4,6 +4,7 @@ import com.github.michaelbull.result.mapBoth
 import dev.betrix.superSmashMobsBrawl.minigames.definitions.MinigameDefinition
 import dev.betrix.superSmashMobsBrawl.services.QueueService
 import dev.betrix.superSmashMobsBrawl.utils.ONLY_PLAYERS_EXEC_MESSAGE
+import dev.betrix.superSmashMobsBrawl.utils.hasDebugEnabled
 import dev.betrix.superSmashMobsBrawl.utils.mm
 import dev.rollczi.litecommands.annotations.argument.Arg
 import dev.rollczi.litecommands.annotations.command.Command
@@ -32,6 +33,11 @@ class QueueCommand() {
             }
 
         sender.sendMessage(playerMessage)
+        
+        // Example debug usage - show additional information if debug is enabled
+        if (sender.hasDebugEnabled()) {
+            sender.sendMessage(mm("<gray>[DEBUG] Queue status checked at ${System.currentTimeMillis()}</gray>"))
+        }
     }
 
     @Execute

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/commands/QueueCommand.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/commands/QueueCommand.kt
@@ -2,9 +2,9 @@ package dev.betrix.superSmashMobsBrawl.commands
 
 import com.github.michaelbull.result.mapBoth
 import dev.betrix.superSmashMobsBrawl.minigames.definitions.MinigameDefinition
+import dev.betrix.superSmashMobsBrawl.extensions.hasDebugEnabled
 import dev.betrix.superSmashMobsBrawl.services.QueueService
 import dev.betrix.superSmashMobsBrawl.utils.ONLY_PLAYERS_EXEC_MESSAGE
-import dev.betrix.superSmashMobsBrawl.utils.hasDebugEnabled
 import dev.betrix.superSmashMobsBrawl.utils.mm
 import dev.rollczi.litecommands.annotations.argument.Arg
 import dev.rollczi.litecommands.annotations.command.Command

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/extensions/player.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/extensions/player.kt
@@ -1,0 +1,18 @@
+package dev.betrix.superSmashMobsBrawl.extensions
+
+import dev.betrix.superSmashMobsBrawl.services.DebugService
+import org.bukkit.entity.Player
+
+/** 
+ * Check if debug mode is enabled for this player.
+ * 
+ * Usage:
+ * ```kotlin
+ * if (player.hasDebugEnabled()) {
+ *     player.sendMessage("Debug: Some debug information")
+ * }
+ * ```
+ */
+fun Player.hasDebugEnabled(): Boolean {
+    return DebugService.isDebugEnabled(this)
+}

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/DebugService.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/DebugService.kt
@@ -1,0 +1,95 @@
+package dev.betrix.superSmashMobsBrawl.services
+
+import gg.flyte.twilight.event.event
+import org.bukkit.entity.Player
+import org.bukkit.event.player.PlayerQuitEvent
+import org.bukkit.plugin.java.JavaPlugin
+
+/**
+ * Service responsible for managing debug mode state for players.
+ * 
+ * This service provides a simple debug toggle system that allows players with the 'ssmb.debug' permission
+ * to enable/disable debug mode using the `/debug` command. When debug mode is enabled, developers can
+ * show additional debug information to these players anywhere in the codebase.
+ * 
+ * ## Usage for Developers:
+ * 
+ * ### Option 1: Using the extension function (recommended)
+ * ```kotlin
+ * import dev.betrix.superSmashMobsBrawl.utils.hasDebugEnabled
+ * 
+ * if (player.hasDebugEnabled()) {
+ *     player.sendMessage(mm("<gray>[DEBUG] Some debug information</gray>"))
+ * }
+ * ```
+ * 
+ * ### Option 2: Using the service directly
+ * ```kotlin
+ * if (DebugService.isDebugEnabled(player)) {
+ *     player.sendMessage("Debug info here")
+ * }
+ * ```
+ * 
+ * ## Player Usage:
+ * 1. Player must have 'ssmb.debug' permission
+ * 2. Use `/debug` command to toggle debug mode on/off
+ * 3. Debug state is automatically cleaned up when player quits
+ */
+object DebugService {
+    private lateinit var plugin: JavaPlugin
+    private val playersWithDebug = mutableSetOf<Player>()
+
+    /** Initialize the debug service */
+    fun initialize(plugin: JavaPlugin) {
+        this.plugin = plugin
+        registerEvents()
+    }
+
+    /** Register debug-related events */
+    private fun registerEvents() {
+        // Clean up debug state when player quits
+        event<PlayerQuitEvent> {
+            playersWithDebug.remove(player)
+        }
+    }
+
+    /** Toggle debug mode for a player */
+    fun toggleDebug(player: Player): Boolean {
+        return if (playersWithDebug.contains(player)) {
+            playersWithDebug.remove(player)
+            plugin.logger.info("Debug mode disabled for player: ${player.name}")
+            false
+        } else {
+            playersWithDebug.add(player)
+            plugin.logger.info("Debug mode enabled for player: ${player.name}")
+            true
+        }
+    }
+
+    /** Check if a player has debug mode enabled */
+    fun isDebugEnabled(player: Player): Boolean {
+        return playersWithDebug.contains(player)
+    }
+
+    /** Enable debug mode for a player */
+    fun enableDebug(player: Player) {
+        if (!playersWithDebug.contains(player)) {
+            playersWithDebug.add(player)
+            plugin.logger.info("Debug mode enabled for player: ${player.name}")
+        }
+    }
+
+    /** Disable debug mode for a player */
+    fun disableDebug(player: Player) {
+        if (playersWithDebug.contains(player)) {
+            playersWithDebug.remove(player)
+            plugin.logger.info("Debug mode disabled for player: ${player.name}")
+        }
+    }
+
+    /** Clean up debug service */
+    fun teardown() {
+        playersWithDebug.clear()
+        plugin.logger.info("Debug service cleaned up")
+    }
+}

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/DebugService.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/DebugService.kt
@@ -16,7 +16,7 @@ import org.bukkit.plugin.java.JavaPlugin
  * 
  * ### Option 1: Using the extension function (recommended)
  * ```kotlin
- * import dev.betrix.superSmashMobsBrawl.utils.hasDebugEnabled
+ * import dev.betrix.superSmashMobsBrawl.extensions.hasDebugEnabled
  * 
  * if (player.hasDebugEnabled()) {
  *     player.sendMessage(mm("<gray>[DEBUG] Some debug information</gray>"))

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/utils/player.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/utils/player.kt
@@ -1,7 +1,22 @@
 package dev.betrix.superSmashMobsBrawl.utils
 
+import dev.betrix.superSmashMobsBrawl.services.DebugService
 import org.bukkit.entity.Player
 
 fun isOnGround(player: Player): Boolean {
     return player.location.subtract(0.0, 0.5, 0.0).block.type.isSolid
+}
+
+/** 
+ * Check if debug mode is enabled for this player.
+ * 
+ * Usage:
+ * ```kotlin
+ * if (player.hasDebugEnabled()) {
+ *     player.sendMessage("Debug: Some debug information")
+ * }
+ * ```
+ */
+fun Player.hasDebugEnabled(): Boolean {
+    return DebugService.isDebugEnabled(this)
 }

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/utils/player.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/utils/player.kt
@@ -1,22 +1,7 @@
 package dev.betrix.superSmashMobsBrawl.utils
 
-import dev.betrix.superSmashMobsBrawl.services.DebugService
 import org.bukkit.entity.Player
 
 fun isOnGround(player: Player): Boolean {
     return player.location.subtract(0.0, 0.5, 0.0).block.type.isSolid
-}
-
-/** 
- * Check if debug mode is enabled for this player.
- * 
- * Usage:
- * ```kotlin
- * if (player.hasDebugEnabled()) {
- *     player.sendMessage("Debug: Some debug information")
- * }
- * ```
- */
-fun Player.hasDebugEnabled(): Boolean {
-    return DebugService.isDebugEnabled(this)
 }


### PR DESCRIPTION
Implement a `/debug` command and player-specific debug state system to allow players to toggle debug information display.

---

[Open in Web](https://cursor.com/agents?id=bc-aa896b51-543f-4673-8174-16fe445c88fc) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-aa896b51-543f-4673-8174-16fe445c88fc) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a debug mode that players can toggle using the new /debug command (requires appropriate permission).
  * Players with debug mode enabled receive additional debug information when using certain commands, such as queue status.
* **Improvements**
  * Automatic cleanup of debug state when players disconnect to ensure accurate debug tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->