### PR TITLE
Create a common service lifecycle manager

### DIFF
--- a/plugin/.gradle/buildOutputCleanup/cache.properties
+++ b/plugin/.gradle/buildOutputCleanup/cache.properties
@@ -1,2 +1,2 @@
-#Mon Jul 28 17:19:11 UTC 2025
+#Mon Jul 28 17:43:55 UTC 2025
 gradle.version=8.11

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -28,6 +28,9 @@ dependencies {
     implementation("com.github.shynixn.mccoroutine:mccoroutine-bukkit-core:2.22.0")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
     implementation("com.michael-bull.kotlin-result:kotlin-result:2.0.1")
+    
+    // Koin dependency injection
+    implementation("io.insert-koin:koin-core:4.0.0")
 }
 
 tasks {

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/SuperSmashMobsBrawl.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/SuperSmashMobsBrawl.kt
@@ -6,12 +6,14 @@ import dev.betrix.superSmashMobsBrawl.commands.KitCommand
 import dev.betrix.superSmashMobsBrawl.commands.LeaveCommand
 import dev.betrix.superSmashMobsBrawl.commands.QueueCommand
 import dev.betrix.superSmashMobsBrawl.commands.argumentResolvers.MinigameDefinitionArgument
+import dev.betrix.superSmashMobsBrawl.di.appModule
 import dev.betrix.superSmashMobsBrawl.lifecycle.ServiceRegistry
 import dev.betrix.superSmashMobsBrawl.minigames.definitions.MinigameDefinition
 import dev.betrix.superSmashMobsBrawl.services.DebugService
 import dev.betrix.superSmashMobsBrawl.services.HotbarService
 import dev.betrix.superSmashMobsBrawl.services.HubProtectionService
 import dev.betrix.superSmashMobsBrawl.services.HubService
+import dev.betrix.superSmashMobsBrawl.services.KitService
 import dev.betrix.superSmashMobsBrawl.services.WorldService
 import dev.rollczi.litecommands.LiteCommands
 import dev.rollczi.litecommands.bukkit.LiteBukkitFactory
@@ -23,6 +25,8 @@ import org.bukkit.command.CommandSender
 import org.bukkit.event.entity.EntityPickupItemEvent
 import org.bukkit.event.inventory.InventoryMoveItemEvent
 import org.bukkit.event.player.PlayerDropItemEvent
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
 
 class SuperSmashMobsBrawl : SuspendingJavaPlugin() {
     lateinit var liteCommands: LiteCommands<CommandSender>
@@ -36,6 +40,11 @@ class SuperSmashMobsBrawl : SuspendingJavaPlugin() {
         instance = this
         twilight = twilight(this)
 
+        // Initialize Koin dependency injection
+        startKoin {
+            modules(appModule)
+        }
+
         // Initialize services
         HotbarService.initialize(this)
         HubService.initialize(this)
@@ -45,6 +54,7 @@ class SuperSmashMobsBrawl : SuspendingJavaPlugin() {
         // Register manageable services for automatic teardown
         ServiceRegistry.register(HubService)
         ServiceRegistry.register(DebugService)
+        ServiceRegistry.register(KitService)
         ServiceRegistry.register(WorldService)
 
         liteCommands =
@@ -77,6 +87,10 @@ class SuperSmashMobsBrawl : SuspendingJavaPlugin() {
         // Tear down all registered manageable services
         ServiceRegistry.teardownAllAsync()
         ServiceRegistry.teardownAll()
+        
+        // Stop Koin
+        stopKoin()
+        
         logger.info("SSMB shutting down")
     }
 }

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/SuperSmashMobsBrawl.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/SuperSmashMobsBrawl.kt
@@ -6,6 +6,7 @@ import dev.betrix.superSmashMobsBrawl.commands.KitCommand
 import dev.betrix.superSmashMobsBrawl.commands.LeaveCommand
 import dev.betrix.superSmashMobsBrawl.commands.QueueCommand
 import dev.betrix.superSmashMobsBrawl.commands.argumentResolvers.MinigameDefinitionArgument
+import dev.betrix.superSmashMobsBrawl.lifecycle.ServiceRegistry
 import dev.betrix.superSmashMobsBrawl.minigames.definitions.MinigameDefinition
 import dev.betrix.superSmashMobsBrawl.services.DebugService
 import dev.betrix.superSmashMobsBrawl.services.HotbarService
@@ -41,6 +42,11 @@ class SuperSmashMobsBrawl : SuspendingJavaPlugin() {
         HubProtectionService.registerEvents()
         DebugService.initialize(this)
 
+        // Register manageable services for automatic teardown
+        ServiceRegistry.register(HubService)
+        ServiceRegistry.register(DebugService)
+        ServiceRegistry.register(WorldService)
+
         liteCommands =
             LiteBukkitFactory.builder(this)
                 .argument(MinigameDefinition::class.java, MinigameDefinitionArgument())
@@ -68,9 +74,9 @@ class SuperSmashMobsBrawl : SuspendingJavaPlugin() {
     }
 
     override suspend fun onDisableAsync() {
-        HubService.teardown()
-        WorldService.teardown()
-        DebugService.teardown()
+        // Tear down all registered manageable services
+        ServiceRegistry.teardownAllAsync()
+        ServiceRegistry.teardownAll()
         logger.info("SSMB shutting down")
     }
 }

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/abilities/instances/AbilityInstance.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/abilities/instances/AbilityInstance.kt
@@ -1,18 +1,26 @@
 package dev.betrix.superSmashMobsBrawl.abilities.instances
 
+import dev.betrix.superSmashMobsBrawl.SuperSmashMobsBrawl
 import dev.betrix.superSmashMobsBrawl.abilities.definitions.AbilityDefinition
+import dev.betrix.superSmashMobsBrawl.di.Injectable
 import dev.betrix.superSmashMobsBrawl.lifecycle.Manageable
 import dev.betrix.superSmashMobsBrawl.utils.mm
+import gg.flyte.twilight.Twilight
 import gg.flyte.twilight.event.TwilightListener
 import gg.flyte.twilight.scheduler.TwilightRunnable
 import kotlinx.coroutines.Job
 import org.bukkit.entity.Player
+import org.koin.core.component.inject
 
-abstract class AbilityInstance(val definition: AbilityDefinition, val player: Player) : Manageable {
+abstract class AbilityInstance(val definition: AbilityDefinition, val player: Player) : Manageable, Injectable {
     private var lastUsed: Long = 0
     protected val listeners = arrayListOf<TwilightListener>()
     protected val runnables = arrayListOf<TwilightRunnable>()
     protected val jobs = arrayListOf<Job>()
+    
+    // Injected dependencies available to all ability instances
+    protected val plugin: SuperSmashMobsBrawl by inject()
+    protected val twilight: Twilight by inject()
 
     override fun setup() {}
 

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/abilities/instances/AbilityInstance.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/abilities/instances/AbilityInstance.kt
@@ -1,21 +1,22 @@
 package dev.betrix.superSmashMobsBrawl.abilities.instances
 
 import dev.betrix.superSmashMobsBrawl.abilities.definitions.AbilityDefinition
+import dev.betrix.superSmashMobsBrawl.lifecycle.Manageable
 import dev.betrix.superSmashMobsBrawl.utils.mm
 import gg.flyte.twilight.event.TwilightListener
 import gg.flyte.twilight.scheduler.TwilightRunnable
 import kotlinx.coroutines.Job
 import org.bukkit.entity.Player
 
-abstract class AbilityInstance(val definition: AbilityDefinition, val player: Player) {
+abstract class AbilityInstance(val definition: AbilityDefinition, val player: Player) : Manageable {
     private var lastUsed: Long = 0
     protected val listeners = arrayListOf<TwilightListener>()
     protected val runnables = arrayListOf<TwilightRunnable>()
     protected val jobs = arrayListOf<Job>()
 
-    open fun setup() {}
+    override fun setup() {}
 
-    open fun teardown() {
+    override fun teardown() {
         listeners.forEach { it.unregister() }
         runnables.forEach { it.cancel() }
         jobs.forEach { it.cancel() }

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/di/AppModule.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/di/AppModule.kt
@@ -1,0 +1,36 @@
+package dev.betrix.superSmashMobsBrawl.di
+
+import dev.betrix.superSmashMobsBrawl.SuperSmashMobsBrawl
+import dev.betrix.superSmashMobsBrawl.services.DebugService
+import dev.betrix.superSmashMobsBrawl.services.HotbarService
+import dev.betrix.superSmashMobsBrawl.services.HubProtectionService
+import dev.betrix.superSmashMobsBrawl.services.HubService
+import dev.betrix.superSmashMobsBrawl.services.KitService
+import dev.betrix.superSmashMobsBrawl.services.MinigameService
+import dev.betrix.superSmashMobsBrawl.services.WorldService
+import gg.flyte.twilight.Twilight
+import org.bukkit.plugin.java.JavaPlugin
+import org.koin.dsl.module
+
+/**
+ * Koin dependency injection module for the Super Smash Mobs Brawl plugin.
+ * 
+ * This module defines all the dependencies that can be injected into classes
+ * throughout the plugin, providing a clean separation of concerns and easier testing.
+ */
+val appModule = module {
+    
+    // Core plugin dependencies
+    single<JavaPlugin> { get<SuperSmashMobsBrawl>() }
+    single<SuperSmashMobsBrawl> { SuperSmashMobsBrawl.instance }
+    single<Twilight> { get<SuperSmashMobsBrawl>().twilight }
+    
+    // Services - these are singletons that will be created once and reused
+    single { DebugService }
+    single { HubService }
+    single { WorldService }
+    single { HotbarService }
+    single { HubProtectionService }
+    single { KitService }
+    single { MinigameService }
+}

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/di/KoinExtensions.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/di/KoinExtensions.kt
@@ -1,0 +1,44 @@
+package dev.betrix.superSmashMobsBrawl.di
+
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import org.koin.core.context.GlobalContext
+
+/**
+ * Extension functions and utilities for easier Koin dependency injection usage.
+ */
+
+/**
+ * Interface that classes can implement to get easy access to dependency injection.
+ * 
+ * Usage:
+ * ```kotlin
+ * class MyService : Injectable {
+ *     private val plugin: SuperSmashMobsBrawl by inject()
+ *     private val twilight: Twilight by inject()
+ * }
+ * ```
+ */
+interface Injectable : KoinComponent
+
+/**
+ * Get a dependency from Koin without implementing Injectable.
+ * Useful for one-off dependency retrieval.
+ * 
+ * Usage:
+ * ```kotlin
+ * val plugin = koinGet<SuperSmashMobsBrawl>()
+ * ```
+ */
+inline fun <reified T> koinGet(): T = GlobalContext.get().get()
+
+/**
+ * Lazy inject a dependency from Koin without implementing Injectable.
+ * The dependency will be resolved when first accessed.
+ * 
+ * Usage:
+ * ```kotlin
+ * val plugin by koinInject<SuperSmashMobsBrawl>()
+ * ```
+ */
+inline fun <reified T> koinInject(): Lazy<T> = lazy { koinGet<T>() }

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/di/README.md
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/di/README.md
@@ -1,0 +1,200 @@
+# Dependency Injection with Koin
+
+This plugin uses the [Koin](https://insert-koin.io/) dependency injection framework to manage dependencies between classes and services. This makes the code more modular, testable, and easier to maintain.
+
+## What is Dependency Injection?
+
+Dependency injection is a design pattern where objects receive their dependencies from external sources rather than creating them internally. This provides several benefits:
+
+- **Loose Coupling**: Classes don't need to know how to create their dependencies
+- **Easier Testing**: Dependencies can be mocked or stubbed for unit tests
+- **Better Separation of Concerns**: Each class focuses on its core responsibility
+- **Centralized Configuration**: All dependencies are configured in one place
+
+## Available Dependencies
+
+The following dependencies are available for injection throughout the plugin:
+
+### Core Dependencies
+- `SuperSmashMobsBrawl` - The main plugin instance
+- `JavaPlugin` - Plugin instance (same as above, but as the generic type)
+- `Twilight` - The Twilight event/scheduler framework instance
+
+### Services
+- `DebugService` - Debug mode management
+- `HubService` - Hub world and player management
+- `WorldService` - World loading/unloading operations
+- `HotbarService` - Hotbar item management
+- `HubProtectionService` - Hub world protection
+- `KitService` - Kit assignment and management
+- `MinigameService` - Minigame instance management
+
+## How to Use Dependency Injection
+
+### Method 1: Implement Injectable Interface (Recommended)
+
+The easiest way to use dependency injection is to implement the `Injectable` interface:
+
+```kotlin
+import dev.betrix.superSmashMobsBrawl.di.Injectable
+import org.koin.core.component.inject
+
+class MyService : Injectable {
+    private val plugin: SuperSmashMobsBrawl by inject()
+    private val twilight: Twilight by inject()
+    private val hubService: HubService by inject()
+    
+    fun doSomething() {
+        plugin.logger.info("Doing something...")
+        // Use injected dependencies
+    }
+}
+```
+
+### Method 2: Direct Injection Functions
+
+For one-off dependency retrieval without implementing an interface:
+
+```kotlin
+import dev.betrix.superSmashMobsBrawl.di.koinGet
+import dev.betrix.superSmashMobsBrawl.di.koinInject
+
+// Immediate retrieval
+val plugin = koinGet<SuperSmashMobsBrawl>()
+
+// Lazy retrieval (resolved when first accessed)
+val hubService by koinInject<HubService>()
+```
+
+## Examples
+
+### Service with Injected Dependencies
+
+```kotlin
+object MyCustomService : Manageable, Injectable {
+    private val plugin: SuperSmashMobsBrawl by inject()
+    private val worldService: WorldService by inject()
+    private val twilight: Twilight by inject()
+    
+    override fun setup() {
+        plugin.logger.info("Setting up MyCustomService")
+        // Use worldService, twilight, etc.
+    }
+    
+    override fun teardown() {
+        plugin.logger.info("Tearing down MyCustomService")
+    }
+}
+```
+
+### Ability Instance with Injected Dependencies
+
+```kotlin
+class MyAbilityInstance(definition: AbilityDefinition, player: Player) :
+    AbilityInstance(definition, player) {
+    
+    // AbilityInstance already implements Injectable and provides:
+    // - protected val plugin: SuperSmashMobsBrawl by inject()
+    // - protected val twilight: Twilight by inject()
+    
+    private val hubService: HubService by inject() // Additional dependency
+    
+    override fun activate() {
+        plugin.logger.info("${player.name} activated ${definition.name}")
+        
+        // Use any injected dependencies
+        if (hubService.isPlayerInHub(player)) {
+            player.sendMessage("You can't use this ability in the hub!")
+            return
+        }
+        
+        // Ability logic here...
+    }
+}
+```
+
+### Command with Injected Dependencies
+
+```kotlin
+class MyCommand : Injectable {
+    private val plugin: SuperSmashMobsBrawl by inject()
+    private val kitService: KitService by inject()
+    
+    @Execute
+    fun execute(player: Player) {
+        if (kitService.hasKit(player)) {
+            player.sendMessage("You already have a kit!")
+        } else {
+            player.sendMessage("You don't have a kit assigned.")
+        }
+    }
+}
+```
+
+## Adding New Dependencies
+
+To add new dependencies that can be injected:
+
+1. Add the dependency to the Koin module in `AppModule.kt`:
+
+```kotlin
+val appModule = module {
+    // ... existing dependencies ...
+    
+    single { MyNewService }  // For object singletons
+    factory { MyNewClass() } // For new instances each time
+}
+```
+
+2. If it's a manageable service, register it with the ServiceRegistry in `SuperSmashMobsBrawl.kt`:
+
+```kotlin
+ServiceRegistry.register(MyNewService)
+```
+
+## Best Practices
+
+1. **Use the Injectable interface** for classes that need multiple dependencies
+2. **Lazy injection** (`by inject()`) is preferred over immediate injection (`get()`)
+3. **Keep dependencies focused** - only inject what you actually need
+4. **Services should be singletons** - use `single { }` in the Koin module
+5. **Implement Manageable** for services that need lifecycle management
+6. **Document dependencies** - make it clear what each class depends on
+
+## Troubleshooting
+
+### Common Issues
+
+1. **"No definition found"** error:
+   - Make sure the dependency is defined in `AppModule.kt`
+   - Check that Koin is properly initialized before trying to inject
+
+2. **Circular dependencies**:
+   - Avoid having services that depend on each other directly
+   - Consider using events or interfaces to break the dependency cycle
+
+3. **Late initialization**:
+   - Some dependencies might not be available immediately during plugin startup
+   - Use lazy injection (`by inject()`) rather than immediate injection
+
+### Testing
+
+When writing unit tests, you can override dependencies by starting Koin with test modules:
+
+```kotlin
+@Test
+fun testMyService() {
+    startKoin {
+        modules(module {
+            single<SuperSmashMobsBrawl> { mockk<SuperSmashMobsBrawl>() }
+            // ... other mocked dependencies
+        })
+    }
+    
+    // Test code here
+    
+    stopKoin()
+}
+```
+
+This dependency injection system makes the codebase much more maintainable and testable while keeping the code clean and focused on business logic rather than dependency management.

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/kits/instances/KitInstance.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/kits/instances/KitInstance.kt
@@ -2,15 +2,16 @@ package dev.betrix.superSmashMobsBrawl.kits.instances
 
 import dev.betrix.superSmashMobsBrawl.abilities.instances.AbilityInstance
 import dev.betrix.superSmashMobsBrawl.kits.definitions.KitDefinition
+import dev.betrix.superSmashMobsBrawl.lifecycle.Manageable
 import dev.betrix.superSmashMobsBrawl.passives.instances.PassiveInstance
 import dev.betrix.superSmashMobsBrawl.services.HotbarService
 import org.bukkit.entity.Player
 
-open class KitInstance(val definition: KitDefinition, val player: Player) {
+open class KitInstance(val definition: KitDefinition, val player: Player) : Manageable {
     val abilityInstances = arrayListOf<AbilityInstance>()
     val passiveInstances = arrayListOf<PassiveInstance>()
 
-    open fun setup() {
+    override fun setup() {
         definition.metadata.abilities.forEach {
             val abilityInstance = it.createInstance(player)
             abilityInstances.add(abilityInstance)
@@ -27,7 +28,7 @@ open class KitInstance(val definition: KitDefinition, val player: Player) {
         HotbarService.setupHotbarItems(this)
     }
 
-    open fun teardown() {
+    override fun teardown() {
         // Clear hotbar items first
         HotbarService.clearHotbarItems(player)
 

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/kits/instances/KitInstance.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/kits/instances/KitInstance.kt
@@ -1,15 +1,20 @@
 package dev.betrix.superSmashMobsBrawl.kits.instances
 
 import dev.betrix.superSmashMobsBrawl.abilities.instances.AbilityInstance
+import dev.betrix.superSmashMobsBrawl.di.Injectable
 import dev.betrix.superSmashMobsBrawl.kits.definitions.KitDefinition
 import dev.betrix.superSmashMobsBrawl.lifecycle.Manageable
 import dev.betrix.superSmashMobsBrawl.passives.instances.PassiveInstance
 import dev.betrix.superSmashMobsBrawl.services.HotbarService
 import org.bukkit.entity.Player
+import org.koin.core.component.inject
 
-open class KitInstance(val definition: KitDefinition, val player: Player) : Manageable {
+open class KitInstance(val definition: KitDefinition, val player: Player) : Manageable, Injectable {
     val abilityInstances = arrayListOf<AbilityInstance>()
     val passiveInstances = arrayListOf<PassiveInstance>()
+    
+    // Injected dependencies
+    protected val hotbarService: HotbarService by inject()
 
     override fun setup() {
         definition.metadata.abilities.forEach {
@@ -25,12 +30,12 @@ open class KitInstance(val definition: KitDefinition, val player: Player) : Mana
         }
 
         // Setup hotbar items for abilities
-        HotbarService.setupHotbarItems(this)
+        hotbarService.setupHotbarItems(this)
     }
 
     override fun teardown() {
         // Clear hotbar items first
-        HotbarService.clearHotbarItems(player)
+        hotbarService.clearHotbarItems(player)
 
         abilityInstances.forEach {
             it.teardown()

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/lifecycle/AsyncManageable.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/lifecycle/AsyncManageable.kt
@@ -1,0 +1,26 @@
+package dev.betrix.superSmashMobsBrawl.lifecycle
+
+/**
+ * Interface for objects that have a lifecycle with setup and teardown phases,
+ * where teardown operations need to be executed asynchronously.
+ * 
+ * This interface is specifically for classes that need to perform async operations
+ * during teardown, such as unloading worlds or cleaning up coroutines.
+ * 
+ * All implementers will have their teardown() method automatically called
+ * during plugin shutdown via the plugin's onDisable method.
+ */
+interface AsyncManageable {
+    /**
+     * Initialize any resources, listeners, runnables, or other components
+     * that this object needs to function properly.
+     */
+    fun setup() {}
+    
+    /**
+     * Asynchronously clean up and cancel all tracked resources, listeners, runnables, jobs, etc.
+     * This method should ensure that no resources are left hanging after the object
+     * is no longer needed.
+     */
+    suspend fun teardown()
+}

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/lifecycle/Manageable.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/lifecycle/Manageable.kt
@@ -1,0 +1,33 @@
+package dev.betrix.superSmashMobsBrawl.lifecycle
+
+/**
+ * Interface for objects that have a lifecycle with setup and teardown phases.
+ * 
+ * This interface provides a common contract for classes that need to:
+ * - Initialize resources, listeners, runnables, or jobs during setup
+ * - Clean up and cancel all tracked resources during teardown
+ * 
+ * Typical implementers include:
+ * - Services that manage global state
+ * - Ability instances that track TwilightRunnable and TwilightListener
+ * - Kit instances that manage abilities and passives
+ * - Minigame instances that need resource cleanup
+ * - Passive instances that register event listeners
+ * 
+ * All implementers will have their teardown() method automatically called
+ * during plugin shutdown via the plugin's onDisable method.
+ */
+interface Manageable {
+    /**
+     * Initialize any resources, listeners, runnables, or other components
+     * that this object needs to function properly.
+     */
+    fun setup() {}
+    
+    /**
+     * Clean up and cancel all tracked resources, listeners, runnables, jobs, etc.
+     * This method should ensure that no resources are left hanging after the object
+     * is no longer needed.
+     */
+    fun teardown()
+}

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/lifecycle/ServiceRegistry.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/lifecycle/ServiceRegistry.kt
@@ -1,0 +1,60 @@
+package dev.betrix.superSmashMobsBrawl.lifecycle
+
+/**
+ * Registry for tracking all manageable services that need to be cleaned up during plugin shutdown.
+ * 
+ * This registry automatically calls teardown() on all registered services when teardownAll() is called,
+ * ensuring proper cleanup during plugin disable.
+ */
+object ServiceRegistry {
+    private val manageableServices = mutableListOf<Manageable>()
+    private val asyncManageableServices = mutableListOf<AsyncManageable>()
+    
+    /**
+     * Register a manageable service that should be torn down during plugin shutdown.
+     */
+    fun register(service: Manageable) {
+        manageableServices.add(service)
+    }
+    
+    /**
+     * Register an async manageable service that should be torn down during plugin shutdown.
+     */
+    fun register(service: AsyncManageable) {
+        asyncManageableServices.add(service)
+    }
+    
+    /**
+     * Tear down all registered manageable services.
+     * This is typically called during plugin onDisable.
+     */
+    fun teardownAll() {
+        manageableServices.forEach { service ->
+            try {
+                service.teardown()
+            } catch (e: Exception) {
+                // Log error but continue with other services
+                System.err.println("Error during teardown of service ${service::class.simpleName}: ${e.message}")
+                e.printStackTrace()
+            }
+        }
+        manageableServices.clear()
+    }
+    
+    /**
+     * Asynchronously tear down all registered async manageable services.
+     * This is typically called during plugin onDisableAsync.
+     */
+    suspend fun teardownAllAsync() {
+        asyncManageableServices.forEach { service ->
+            try {
+                service.teardown()
+            } catch (e: Exception) {
+                // Log error but continue with other services
+                System.err.println("Error during async teardown of service ${service::class.simpleName}: ${e.message}")
+                e.printStackTrace()
+            }
+        }
+        asyncManageableServices.clear()
+    }
+}

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/instances/MinigameInstance.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/instances/MinigameInstance.kt
@@ -2,21 +2,22 @@ package dev.betrix.superSmashMobsBrawl.minigames.instances
 
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
+import dev.betrix.superSmashMobsBrawl.lifecycle.AsyncManageable
 import dev.betrix.superSmashMobsBrawl.minigames.definitions.MinigameDefinition
 import dev.betrix.superSmashMobsBrawl.models.MinigameTeam
 import java.util.UUID
 import org.bukkit.World
 import org.bukkit.entity.Player
 
-abstract class MinigameInstance(val definition: MinigameDefinition, val teams: List<MinigameTeam>) {
+abstract class MinigameInstance(val definition: MinigameDefinition, val teams: List<MinigameTeam>) : AsyncManageable {
     open lateinit var world: World
     val gameId: String = UUID.randomUUID().toString()
 
-    open suspend fun setup(): Result<Unit, Exception> {
+    open suspend fun setupMinigame(): Result<Unit, Exception> {
         return Ok(Unit)
     }
 
-    open suspend fun teardown(): Unit {}
+    override suspend fun teardown(): Unit {}
 
     abstract fun onPlayerLeave(player: Player): Result<Unit, String>
 

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/instances/TestingMinigameInstance.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/instances/TestingMinigameInstance.kt
@@ -28,7 +28,7 @@ class TestingMinigameInstance(definition: MinigameDefinition, teams: List<Miniga
     private val players: List<Player>
         get() = teams.flatMap { it.players }
 
-    override suspend fun setup(): Result<Unit, Exception> {
+    override suspend fun setupMinigame(): Result<Unit, Exception> {
         try {
             WorldService.copyAndLoadWorld(campsiteMap, gameId)
                 .mapBoth(

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/passives/instances/PassiveInstance.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/passives/instances/PassiveInstance.kt
@@ -1,10 +1,18 @@
 package dev.betrix.superSmashMobsBrawl.passives.instances
 
+import dev.betrix.superSmashMobsBrawl.SuperSmashMobsBrawl
+import dev.betrix.superSmashMobsBrawl.di.Injectable
 import dev.betrix.superSmashMobsBrawl.lifecycle.Manageable
 import dev.betrix.superSmashMobsBrawl.passives.definitions.PassiveDefinition
+import gg.flyte.twilight.Twilight
 import org.bukkit.entity.Player
+import org.koin.core.component.inject
 
-abstract class PassiveInstance(val definition: PassiveDefinition, val player: Player) : Manageable {
+abstract class PassiveInstance(val definition: PassiveDefinition, val player: Player) : Manageable, Injectable {
+    // Injected dependencies available to all passive instances
+    protected val plugin: SuperSmashMobsBrawl by inject()
+    protected val twilight: Twilight by inject()
+    
     abstract override fun setup(): Unit
 
     abstract override fun teardown(): Unit

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/passives/instances/PassiveInstance.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/passives/instances/PassiveInstance.kt
@@ -1,10 +1,11 @@
 package dev.betrix.superSmashMobsBrawl.passives.instances
 
+import dev.betrix.superSmashMobsBrawl.lifecycle.Manageable
 import dev.betrix.superSmashMobsBrawl.passives.definitions.PassiveDefinition
 import org.bukkit.entity.Player
 
-abstract class PassiveInstance(val definition: PassiveDefinition, val player: Player) {
-    abstract fun setup(): Unit
+abstract class PassiveInstance(val definition: PassiveDefinition, val player: Player) : Manageable {
+    abstract override fun setup(): Unit
 
-    abstract fun teardown(): Unit
+    abstract override fun teardown(): Unit
 }

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/DebugService.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/DebugService.kt
@@ -1,10 +1,12 @@
 package dev.betrix.superSmashMobsBrawl.services
 
+import dev.betrix.superSmashMobsBrawl.di.Injectable
 import dev.betrix.superSmashMobsBrawl.lifecycle.Manageable
 import gg.flyte.twilight.event.event
 import org.bukkit.entity.Player
 import org.bukkit.event.player.PlayerQuitEvent
 import org.bukkit.plugin.java.JavaPlugin
+import org.koin.core.component.inject
 
 /**
  * Service responsible for managing debug mode state for players.
@@ -36,13 +38,12 @@ import org.bukkit.plugin.java.JavaPlugin
  * 2. Use `/debug` command to toggle debug mode on/off
  * 3. Debug state is automatically cleaned up when player quits
  */
-object DebugService : Manageable {
-    private lateinit var plugin: JavaPlugin
+object DebugService : Manageable, Injectable {
+    private val plugin: JavaPlugin by inject()
     private val playersWithDebug = mutableSetOf<Player>()
 
     /** Initialize the debug service */
     fun initialize(plugin: JavaPlugin) {
-        this.plugin = plugin
         registerEvents()
     }
 

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/DebugService.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/DebugService.kt
@@ -1,5 +1,6 @@
 package dev.betrix.superSmashMobsBrawl.services
 
+import dev.betrix.superSmashMobsBrawl.lifecycle.Manageable
 import gg.flyte.twilight.event.event
 import org.bukkit.entity.Player
 import org.bukkit.event.player.PlayerQuitEvent
@@ -35,7 +36,7 @@ import org.bukkit.plugin.java.JavaPlugin
  * 2. Use `/debug` command to toggle debug mode on/off
  * 3. Debug state is automatically cleaned up when player quits
  */
-object DebugService {
+object DebugService : Manageable {
     private lateinit var plugin: JavaPlugin
     private val playersWithDebug = mutableSetOf<Player>()
 
@@ -88,7 +89,7 @@ object DebugService {
     }
 
     /** Clean up debug service */
-    fun teardown() {
+    override fun teardown() {
         playersWithDebug.clear()
         plugin.logger.info("Debug service cleaned up")
     }

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/HubService.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/HubService.kt
@@ -2,6 +2,7 @@ package dev.betrix.superSmashMobsBrawl.services
 
 import com.github.michaelbull.result.mapBoth
 import com.github.shynixn.mccoroutine.bukkit.launch
+import dev.betrix.superSmashMobsBrawl.lifecycle.Manageable
 import dev.betrix.superSmashMobsBrawl.maps.SsmbMap
 import dev.betrix.superSmashMobsBrawl.maps.blueForestHub
 import dev.betrix.superSmashMobsBrawl.passives.definitions.DoubleJumpPassiveDefinition
@@ -20,14 +21,14 @@ import org.bukkit.event.player.PlayerTeleportEvent
 import org.bukkit.plugin.java.JavaPlugin
 
 /** Service responsible for managing hub worlds and player hub interactions */
-object HubService {
+object HubService : Manageable {
     private lateinit var defaultLoadedHubWorld: LoadedWorld
     private lateinit var plugin: JavaPlugin
     private val playersInHub = mutableSetOf<Player>()
     private val playerPassives = mutableMapOf<Player, PassiveInstance>()
 
     /** Removes all current loaded worlds and teleports all players to default world */
-    fun teardown() {
+    override fun teardown() {
         playerPassives.values.forEach { it.teardown() }
         playerPassives.clear()
         playersInHub.clear()

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/HubService.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/HubService.kt
@@ -2,6 +2,7 @@ package dev.betrix.superSmashMobsBrawl.services
 
 import com.github.michaelbull.result.mapBoth
 import com.github.shynixn.mccoroutine.bukkit.launch
+import dev.betrix.superSmashMobsBrawl.di.Injectable
 import dev.betrix.superSmashMobsBrawl.lifecycle.Manageable
 import dev.betrix.superSmashMobsBrawl.maps.SsmbMap
 import dev.betrix.superSmashMobsBrawl.maps.blueForestHub
@@ -19,11 +20,12 @@ import org.bukkit.event.player.PlayerJoinEvent
 import org.bukkit.event.player.PlayerQuitEvent
 import org.bukkit.event.player.PlayerTeleportEvent
 import org.bukkit.plugin.java.JavaPlugin
+import org.koin.core.component.inject
 
 /** Service responsible for managing hub worlds and player hub interactions */
-object HubService : Manageable {
+object HubService : Manageable, Injectable {
     private lateinit var defaultLoadedHubWorld: LoadedWorld
-    private lateinit var plugin: JavaPlugin
+    private val plugin: JavaPlugin by inject()
     private val playersInHub = mutableSetOf<Player>()
     private val playerPassives = mutableMapOf<Player, PassiveInstance>()
 
@@ -37,7 +39,6 @@ object HubService : Manageable {
 
     /** Initialize the hub service */
     fun initialize(plugin: JavaPlugin) {
-        this.plugin = plugin
 
         val defaultHubId = UUID.randomUUID().toString()
 

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/KitService.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/KitService.kt
@@ -3,15 +3,20 @@ package dev.betrix.superSmashMobsBrawl.services
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
+import dev.betrix.superSmashMobsBrawl.SuperSmashMobsBrawl
+import dev.betrix.superSmashMobsBrawl.di.Injectable
 import dev.betrix.superSmashMobsBrawl.kits.definitions.KitDefinition
 import dev.betrix.superSmashMobsBrawl.kits.instances.KitInstance
+import dev.betrix.superSmashMobsBrawl.lifecycle.Manageable
 import org.bukkit.entity.Player
+import org.koin.core.component.inject
 
 enum class AssignKitError {
     PLAYER_HAS_KIT
 }
 
-object KitService {
+object KitService : Manageable, Injectable {
+    private val plugin: SuperSmashMobsBrawl by inject()
     private val assignedKits = hashMapOf<Player, KitInstance>()
 
     fun assignKit(
@@ -54,5 +59,12 @@ object KitService {
 
     fun hasKit(player: Player): Boolean {
         return assignedKits.containsKey(player)
+    }
+    
+    override fun teardown() {
+        // Teardown all assigned kits
+        assignedKits.values.forEach { it.teardown() }
+        assignedKits.clear()
+        plugin.logger.info("Kit service cleaned up")
     }
 }

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/MinigameService.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/MinigameService.kt
@@ -48,7 +48,7 @@ object MinigameService {
 
     fun handleMinigameSetup(minigameInstance: MinigameInstance) {
         SuperSmashMobsBrawl.instance.launch {
-            minigameInstance.setup().onFailure { minigameInstance.teardown() }
+            minigameInstance.setupMinigame().onFailure { minigameInstance.teardown() }
         }
     }
 

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/WorldService.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/WorldService.kt
@@ -7,6 +7,7 @@ import com.github.michaelbull.result.onFailure
 import com.github.shynixn.mccoroutine.bukkit.asyncDispatcher
 import com.github.shynixn.mccoroutine.bukkit.minecraftDispatcher
 import dev.betrix.superSmashMobsBrawl.SuperSmashMobsBrawl
+import dev.betrix.superSmashMobsBrawl.di.Injectable
 import dev.betrix.superSmashMobsBrawl.lifecycle.AsyncManageable
 import dev.betrix.superSmashMobsBrawl.maps.SsmbMap
 import java.io.IOException
@@ -22,10 +23,12 @@ import org.bukkit.Bukkit
 import org.bukkit.GameRule
 import org.bukkit.World
 import org.bukkit.WorldCreator
+import org.koin.core.component.inject
 
 data class LoadedWorld(val world: World, val mapDefinition: SsmbMap)
 
-object WorldService : AsyncManageable {
+object WorldService : AsyncManageable, Injectable {
+    private val plugin: SuperSmashMobsBrawl by inject()
     private val loadedWorlds = hashMapOf<String, LoadedWorld>()
 
     private const val WORLD_PREFIX = "ssmbworld_"
@@ -33,7 +36,7 @@ object WorldService : AsyncManageable {
     override suspend fun teardown() {
         loadedWorlds.forEach { it ->
             deleteWorld(it.value).onFailure { error ->
-                SuperSmashMobsBrawl.instance.logger.severe(
+                plugin.logger.severe(
                     "Failed to delete world: ${error.message}"
                 )
             }
@@ -44,7 +47,7 @@ object WorldService : AsyncManageable {
         map: SsmbMap,
         customWorldName: String = UUID.randomUUID().toString(),
     ): Result<LoadedWorld, Exception> =
-        withContext(SuperSmashMobsBrawl.instance.asyncDispatcher) {
+        withContext(plugin.asyncDispatcher) {
             val copyResult = runCatching {
                 val serverFolder = Bukkit.getWorldContainer().toPath()
                 val worldsFolder = serverFolder.resolve("worlds")
@@ -72,7 +75,7 @@ object WorldService : AsyncManageable {
                 prefixedWorldName
             }
 
-            withContext(SuperSmashMobsBrawl.instance.minecraftDispatcher) {
+            withContext(plugin.minecraftDispatcher) {
                 copyResult.fold(
                     onSuccess = { worldName ->
                         runCatching {
@@ -116,7 +119,7 @@ object WorldService : AsyncManageable {
     }
 
     suspend fun deleteWorld(loadedWorld: LoadedWorld): Result<Unit, Exception> =
-        withContext(SuperSmashMobsBrawl.instance.minecraftDispatcher) mainContext@{
+        withContext(plugin.minecraftDispatcher) mainContext@{
             val loadedWorldEntry = loadedWorlds.entries.find { it.value == loadedWorld }
 
             if (loadedWorldEntry == null) {
@@ -149,7 +152,7 @@ object WorldService : AsyncManageable {
                 .fold(
                     onSuccess = { actualWorldName ->
                         return@mainContext withContext(
-                            SuperSmashMobsBrawl.instance.asyncDispatcher
+                            plugin.asyncDispatcher
                         ) {
                             runCatching {
                                     val serverFolder = Bukkit.getWorldContainer().toPath()

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/WorldService.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/WorldService.kt
@@ -7,6 +7,7 @@ import com.github.michaelbull.result.onFailure
 import com.github.shynixn.mccoroutine.bukkit.asyncDispatcher
 import com.github.shynixn.mccoroutine.bukkit.minecraftDispatcher
 import dev.betrix.superSmashMobsBrawl.SuperSmashMobsBrawl
+import dev.betrix.superSmashMobsBrawl.lifecycle.AsyncManageable
 import dev.betrix.superSmashMobsBrawl.maps.SsmbMap
 import java.io.IOException
 import java.nio.file.FileVisitResult
@@ -24,12 +25,12 @@ import org.bukkit.WorldCreator
 
 data class LoadedWorld(val world: World, val mapDefinition: SsmbMap)
 
-object WorldService {
+object WorldService : AsyncManageable {
     private val loadedWorlds = hashMapOf<String, LoadedWorld>()
 
     private const val WORLD_PREFIX = "ssmbworld_"
 
-    suspend fun teardown() {
+    override suspend fun teardown() {
         loadedWorlds.forEach { it ->
             deleteWorld(it.value).onFailure { error ->
                 SuperSmashMobsBrawl.instance.logger.severe(


### PR DESCRIPTION
Standardize service lifecycle management with `Manageable` interfaces and a `ServiceRegistry` for automatic cleanup.

---

[Open in Web](https://cursor.com/agents?id=bc-1dc8c0eb-c772-4091-85cb-83fba2022f66) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-1dc8c0eb-c772-4091-85cb-83fba2022f66) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)