### PR TITLE
Add hunger passive to smash mobs

### DIFF
--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/abilities/instances/ExplosionAbilityInstance.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/abilities/instances/ExplosionAbilityInstance.kt
@@ -5,6 +5,7 @@ import com.github.shynixn.mccoroutine.bukkit.launch
 import com.github.shynixn.mccoroutine.bukkit.ticks
 import dev.betrix.superSmashMobsBrawl.SuperSmashMobsBrawl
 import dev.betrix.superSmashMobsBrawl.abilities.definitions.AbilityDefinition
+import dev.betrix.superSmashMobsBrawl.events.Damager
 import dev.betrix.superSmashMobsBrawl.events.SmashDamageEvent
 import dev.betrix.superSmashMobsBrawl.events.SmashDamageType
 import dev.betrix.superSmashMobsBrawl.extensions.doKnockback
@@ -123,7 +124,7 @@ class ExplosionAbilityInstance(definition: AbilityDefinition, player: Player) :
                         val damageEvent =
                             SmashDamageEvent(
                                 entity,
-                                player,
+                                Damager.LivingEntity(player),
                                 damage,
                                 explosionKnockbackMultiplier,
                                 SmashDamageType.Explosion,

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/abilities/instances/SulphurBombAbilityInstance.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/abilities/instances/SulphurBombAbilityInstance.kt
@@ -1,6 +1,7 @@
 package dev.betrix.superSmashMobsBrawl.abilities.instances
 
 import dev.betrix.superSmashMobsBrawl.abilities.definitions.AbilityDefinition
+import dev.betrix.superSmashMobsBrawl.events.Damager
 import dev.betrix.superSmashMobsBrawl.events.SmashDamageEvent
 import dev.betrix.superSmashMobsBrawl.events.SmashDamageType
 import dev.betrix.superSmashMobsBrawl.extensions.doKnockback
@@ -40,7 +41,7 @@ class SulphurBombAbilityInstance(definition: AbilityDefinition, player: Player) 
                     val damageEvent =
                         SmashDamageEvent(
                             target,
-                            player,
+                            Damager.LivingEntity(player),
                             projectileDamage,
                             0.0,
                             SmashDamageType.Projectile,

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/events/SmashDamageEvent.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/events/SmashDamageEvent.kt
@@ -11,9 +11,14 @@ sealed class SmashDamageType {
     object Explosion : SmashDamageType()
 }
 
+sealed class Damager {
+    object System : Damager()
+    data class LivingEntity(val livingEntity: org.bukkit.entity.LivingEntity) : Damager()
+}
+
 class SmashDamageEvent(
     val victim: LivingEntity,
-    val damager: LivingEntity?,
+    val damager: Damager?,
     val damage: Double,
     val knockbackMultiplier: Double = 1.0,
     val damageType: SmashDamageType? = null,
@@ -22,10 +27,21 @@ class SmashDamageEvent(
     fun isValid(minigame: MinigameInstance): Boolean {
         // TODO: Once we figure out how we want to handle all living entities in minigames, this
         // check will be removed
-        if (victim !is Player || damager !is Player) {
+        if (victim !is Player) {
+            return false
+        }
+        
+        // Check if damager is a player when it's a LivingEntity
+        val damagerPlayer = when (damager) {
+            is Damager.LivingEntity -> damager.livingEntity as? Player
+            is Damager.System -> return minigame.isPlayerInMinigame(victim)
+            null -> return false
+        }
+        
+        if (damagerPlayer == null) {
             return false
         }
 
-        return minigame.isPlayerInMinigame(damager) && minigame.isPlayerInMinigame(victim)
+        return minigame.isPlayerInMinigame(damagerPlayer) && minigame.isPlayerInMinigame(victim)
     }
 }

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/passives/definitions/HungerPassiveDefinition.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/passives/definitions/HungerPassiveDefinition.kt
@@ -10,7 +10,7 @@ object HungerPassiveDefinition : PassiveDefinition() {
 
     override val metadata = passive {
         description = "Damages the player if they haven't dealt damage in a while"
-        userFacing = true
+        userFacing = false
     }
 
     override fun createInstance(player: Player): HungerInstance {

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/passives/definitions/HungerPassiveDefinition.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/passives/definitions/HungerPassiveDefinition.kt
@@ -1,0 +1,19 @@
+package dev.betrix.superSmashMobsBrawl.passives.definitions
+
+import dev.betrix.superSmashMobsBrawl.passives.instances.HungerInstance
+import dev.betrix.superSmashMobsBrawl.passives.passive
+import org.bukkit.entity.Player
+
+object HungerPassiveDefinition : PassiveDefinition() {
+    override val name = "Hunger"
+    override val id = "hunger"
+
+    override val metadata = passive {
+        description = "Damages the player if they haven't dealt damage in a while"
+        userFacing = true
+    }
+
+    override fun createInstance(player: Player): HungerInstance {
+        return HungerInstance(this, player)
+    }
+}

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/passives/instances/HungerInstance.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/passives/instances/HungerInstance.kt
@@ -1,0 +1,70 @@
+package dev.betrix.superSmashMobsBrawl.passives.instances
+
+import dev.betrix.superSmashMobsBrawl.events.SmashDamageEvent
+import dev.betrix.superSmashMobsBrawl.passives.definitions.PassiveDefinition
+import gg.flyte.twilight.event.event
+import gg.flyte.twilight.scheduler.TwilightRunnable
+import gg.flyte.twilight.scheduler.repeatingTask
+import org.bukkit.entity.Player
+import org.bukkit.event.entity.PlayerDeathEvent
+
+class HungerInstance(definition: PassiveDefinition, player: Player) :
+    PassiveInstance(definition, player) {
+    
+    private var lastDamageTime = System.currentTimeMillis()
+    private val hungerDelay = 10000L // 10 seconds without dealing damage before hunger starts
+    private val hungerDamage = 1.0 // Damage per tick
+    private val hungerInterval = 20L // Ticks between hunger damage (1 second)
+    private val maxHungerLevel = 20 // Maximum hunger level (full bar)
+    
+    private var hungerTask: TwilightRunnable? = null
+    
+    override fun setup() {
+        // Listen for when this player deals damage
+        event<SmashDamageEvent> {
+            if (damager != this@HungerInstance.player) return@event
+            
+            // Reset the last damage time
+            lastDamageTime = System.currentTimeMillis()
+            
+            // Restore hunger if they deal damage
+            if (player.foodLevel < maxHungerLevel) {
+                player.foodLevel = (player.foodLevel + 2).coerceAtMost(maxHungerLevel)
+            }
+        }
+        
+        // Listen for player death to reset
+        event<PlayerDeathEvent> {
+            if (player != this@HungerInstance.player) return@event
+            
+            // Reset on death
+            lastDamageTime = System.currentTimeMillis()
+            player.foodLevel = maxHungerLevel
+        }
+        
+        // Start the hunger check task
+        hungerTask = repeatingTask(hungerInterval) {
+            val currentTime = System.currentTimeMillis()
+            val timeSinceLastDamage = currentTime - lastDamageTime
+            
+            // If player hasn't dealt damage in a while, start depleting hunger
+            if (timeSinceLastDamage > hungerDelay) {
+                // Reduce hunger bar
+                if (player.foodLevel > 0) {
+                    player.foodLevel = (player.foodLevel - 1).coerceAtLeast(0)
+                }
+                
+                // If hunger is depleted, deal damage
+                if (player.foodLevel <= 0 && player.health > 0) {
+                    player.damage(hungerDamage)
+                }
+            }
+        }
+    }
+    
+    override fun teardown() {
+        hungerTask?.cancel()
+        // Restore full hunger when passive is removed
+        player.foodLevel = maxHungerLevel
+    }
+}

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/passives/instances/HungerInstance.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/passives/instances/HungerInstance.kt
@@ -6,22 +6,24 @@ import dev.betrix.superSmashMobsBrawl.passives.definitions.PassiveDefinition
 import gg.flyte.twilight.event.event
 import gg.flyte.twilight.scheduler.TwilightRunnable
 import gg.flyte.twilight.scheduler.repeatingTask
+import org.bukkit.GameMode
 import org.bukkit.entity.Player
 import org.bukkit.event.entity.PlayerDeathEvent
+import kotlin.math.max
+import kotlin.math.min
 
 class HungerInstance(definition: PassiveDefinition, player: Player) :
     PassiveInstance(definition, player) {
     
-    private var lastDamageTime = System.currentTimeMillis()
-    private val hungerDelay = 10000L // 10 seconds without dealing damage before hunger starts
-    private val hungerDamage = 1.0 // Damage per tick
-    private val hungerInterval = 20L // Ticks between hunger damage (1 second)
-    private val maxHungerLevel = 20 // Maximum hunger level (full bar)
+    private val secondsToDrain = 10.0
+    private val hungerRestoreDelayMs = 250L
+    private var hungerTicks = 0L
+    private var lastHungerRestoreMs = System.currentTimeMillis()
     
     private var hungerTask: TwilightRunnable? = null
     
     override fun setup() {
-        // Listen for when this player deals damage
+        // Listen for when this player deals damage to restore hunger
         event<SmashDamageEvent> {
             // Check if this player is the damager
             val isThisPlayerDamager = when (damager) {
@@ -32,53 +34,79 @@ class HungerInstance(definition: PassiveDefinition, player: Player) :
             
             if (!isThisPlayerDamager) return@event
             
-            // Reset the last damage time
-            lastDamageTime = System.currentTimeMillis()
-            
-            // Restore hunger if they deal damage
-            if (player.foodLevel < maxHungerLevel) {
-                player.foodLevel = (player.foodLevel + 2).coerceAtMost(maxHungerLevel)
-            }
+            // Restore hunger based on damage dealt
+            hungerRestore(damage)
         }
         
         // Listen for player death to reset
         event<PlayerDeathEvent> {
             if (player != this@HungerInstance.player) return@event
             
-            // Reset on death
-            lastDamageTime = System.currentTimeMillis()
-            player.foodLevel = maxHungerLevel
+            // Reset hunger on death
+            player.foodLevel = 20
+            lastHungerRestoreMs = System.currentTimeMillis()
         }
         
-        // Start the hunger check task
-        hungerTask = repeatingTask(hungerInterval) {
-            val currentTime = System.currentTimeMillis()
-            val timeSinceLastDamage = currentTime - lastDamageTime
-            
-            // If player hasn't dealt damage in a while, start depleting hunger
-            if (timeSinceLastDamage > hungerDelay) {
-                // Reduce hunger bar
-                if (player.foodLevel > 0) {
-                    player.foodLevel = (player.foodLevel - 1).coerceAtLeast(0)
-                }
-                
-                // If hunger is depleted, deal damage using SmashDamageEvent
-                if (player.foodLevel <= 0 && player.health > 0) {
-                    val damageEvent = SmashDamageEvent(
-                        victim = player,
-                        damager = Damager.System,
-                        damage = hungerDamage,
-                        knockbackMultiplier = 0.0 // No knockback from hunger damage
-                    )
-                    damageEvent.callEvent()
-                }
-            }
+        // Start the hunger task that runs every tick (20 times per second)
+        hungerTask = repeatingTask(1L) {
+            activate()
         }
+    }
+    
+    private fun activate() {
+        // Skip if player is in creative mode
+        if (player.gameMode == GameMode.CREATIVE) {
+            return
+        }
+        
+        // Increment hunger ticks and wrap around at 10
+        hungerTicks = (hungerTicks + 1) % 10
+        
+        // Set saturation and exhaustion to prevent natural hunger depletion
+        player.saturation = 3f
+        player.exhaustion = 0f
+        
+        // If food level is 0, deal damage
+        if (player.foodLevel <= 0) {
+            // TODO: Send message to player when server messaging system is available
+            // "Attack other players to restore hunger!"
+            
+            val damageEvent = SmashDamageEvent(
+                victim = player,
+                damager = Damager.System,
+                damage = 1.0,
+                knockbackMultiplier = 0.0
+            )
+            // Note: In the Java version they set damage cause, damager name, and reason
+            // but our SmashDamageEvent doesn't have those fields currently
+            damageEvent.callEvent()
+            return
+        }
+        
+        // Every 10 ticks (0.5 seconds), reduce food level by 1
+        if (hungerTicks == 0L) {
+            player.foodLevel = max(0, player.foodLevel - 1)
+        }
+    }
+    
+    private fun hungerRestore(damage: Double) {
+        // Check if enough time has passed since last restore
+        if ((System.currentTimeMillis() - lastHungerRestoreMs) < hungerRestoreDelayMs) {
+            return
+        }
+        
+        lastHungerRestoreMs = System.currentTimeMillis()
+        
+        // Calculate amount to restore (half of damage dealt, minimum 1)
+        val amount = max(1, (damage / 2).toInt())
+        
+        // Restore food level, capped at 20
+        player.foodLevel = min(20, player.foodLevel + amount)
     }
     
     override fun teardown() {
         hungerTask?.cancel()
         // Restore full hunger when passive is removed
-        player.foodLevel = maxHungerLevel
+        player.foodLevel = 20
     }
 }

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/passives/instances/HungerInstance.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/passives/instances/HungerInstance.kt
@@ -1,5 +1,6 @@
 package dev.betrix.superSmashMobsBrawl.passives.instances
 
+import dev.betrix.superSmashMobsBrawl.events.Damager
 import dev.betrix.superSmashMobsBrawl.events.SmashDamageEvent
 import dev.betrix.superSmashMobsBrawl.passives.definitions.PassiveDefinition
 import gg.flyte.twilight.event.event
@@ -22,7 +23,14 @@ class HungerInstance(definition: PassiveDefinition, player: Player) :
     override fun setup() {
         // Listen for when this player deals damage
         event<SmashDamageEvent> {
-            if (damager != this@HungerInstance.player) return@event
+            // Check if this player is the damager
+            val isThisPlayerDamager = when (damager) {
+                is Damager.LivingEntity -> damager.livingEntity == this@HungerInstance.player
+                is Damager.System -> false
+                null -> false
+            }
+            
+            if (!isThisPlayerDamager) return@event
             
             // Reset the last damage time
             lastDamageTime = System.currentTimeMillis()
@@ -54,9 +62,15 @@ class HungerInstance(definition: PassiveDefinition, player: Player) :
                     player.foodLevel = (player.foodLevel - 1).coerceAtLeast(0)
                 }
                 
-                // If hunger is depleted, deal damage
+                // If hunger is depleted, deal damage using SmashDamageEvent
                 if (player.foodLevel <= 0 && player.health > 0) {
-                    player.damage(hungerDamage)
+                    val damageEvent = SmashDamageEvent(
+                        victim = player,
+                        damager = Damager.System,
+                        damage = hungerDamage,
+                        knockbackMultiplier = 0.0 // No knockback from hunger damage
+                    )
+                    damageEvent.callEvent()
                 }
             }
         }

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/passives/instances/HungerInstance.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/passives/instances/HungerInstance.kt
@@ -3,6 +3,7 @@ package dev.betrix.superSmashMobsBrawl.passives.instances
 import dev.betrix.superSmashMobsBrawl.events.Damager
 import dev.betrix.superSmashMobsBrawl.events.SmashDamageEvent
 import dev.betrix.superSmashMobsBrawl.passives.definitions.PassiveDefinition
+import dev.betrix.superSmashMobsBrawl.utils.mm
 import gg.flyte.twilight.event.event
 import gg.flyte.twilight.scheduler.TwilightRunnable
 import gg.flyte.twilight.scheduler.repeatingTask
@@ -68,8 +69,7 @@ class HungerInstance(definition: PassiveDefinition, player: Player) :
         
         // If food level is 0, deal damage
         if (player.foodLevel <= 0) {
-            // TODO: Send message to player when server messaging system is available
-            // "Attack other players to restore hunger!"
+            player.sendMessage(mm("<red>Attack other players to restore hunger!</red>"))
             
             val damageEvent = SmashDamageEvent(
                 victim = player,

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/registries/PassiveRegistry.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/registries/PassiveRegistry.kt
@@ -2,6 +2,7 @@ package dev.betrix.superSmashMobsBrawl.registries
 
 import dev.betrix.superSmashMobsBrawl.passives.definitions.DoubleJumpPassiveDefinition
 import dev.betrix.superSmashMobsBrawl.passives.definitions.ExplosiveFeedbackPassiveDefinition
+import dev.betrix.superSmashMobsBrawl.passives.definitions.HungerPassiveDefinition
 import dev.betrix.superSmashMobsBrawl.passives.definitions.PassiveDefinition
 
 object PassiveRegistry {
@@ -18,5 +19,6 @@ object PassiveRegistry {
     init {
         register(DoubleJumpPassiveDefinition)
         register(ExplosiveFeedbackPassiveDefinition)
+        register(HungerPassiveDefinition)
     }
 }


### PR DESCRIPTION
Add a Hunger passive that damages players for not dealing damage to encourage aggressive gameplay.

---
<a href="https://cursor.com/background-agent?bcId=bc-38557891-1fc1-4672-abc4-5ce77a4b6c06">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-38557891-1fc1-4672-abc4-5ce77a4b6c06">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new "Hunger" passive ability that causes players to take damage if they haven't dealt damage for a period of time. Players can restore hunger by attacking others.
* **Improvements**
  * Enhanced damage event handling to better represent different sources of damage, improving accuracy in event tracking and gameplay interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->