### PR TITLE
Duels minigame

### DIFF
--- a/plugin/.gradle/buildOutputCleanup/cache.properties
+++ b/plugin/.gradle/buildOutputCleanup/cache.properties
@@ -1,2 +1,2 @@
-#Mon Jul 28 17:19:11 UTC 2025
+#Wed Jul 30 02:57:00 UTC 2025
 gradle.version=8.11

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/Managable.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/Managable.kt
@@ -1,0 +1,31 @@
+package dev.betrix.superSmashMobsBrawl
+
+import gg.flyte.twilight.event.TwilightListener
+import gg.flyte.twilight.scheduler.TwilightRunnable
+import kotlinx.coroutines.Job
+
+abstract class Managable {
+    protected val runnables = arrayListOf<TwilightRunnable>()
+    protected val listeners = arrayListOf<TwilightListener>()
+    protected val jobs = arrayListOf<Job>()
+
+    open fun setupAsync() {
+        setup()
+    }
+
+    open fun setup() {}
+
+    open fun teardownAsync() {
+        teardown()
+    }
+
+    open fun teardown() {
+        runnables.forEach { it.cancel() }
+        listeners.forEach { it.unregister() }
+        jobs.forEach { it.cancel() }
+
+        runnables.clear()
+        listeners.clear()
+        jobs.clear()
+    }
+}

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/Manageable.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/Manageable.kt
@@ -4,18 +4,18 @@ import gg.flyte.twilight.event.TwilightListener
 import gg.flyte.twilight.scheduler.TwilightRunnable
 import kotlinx.coroutines.Job
 
-abstract class Managable {
+abstract class Manageable {
     protected val runnables = arrayListOf<TwilightRunnable>()
     protected val listeners = arrayListOf<TwilightListener>()
     protected val jobs = arrayListOf<Job>()
 
-    open fun setupAsync() {
+    open suspend fun setupAsync() {
         setup()
     }
 
     open fun setup() {}
 
-    open fun teardownAsync() {
+    open suspend fun teardownAsync() {
         teardown()
     }
 

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/SuperSmashMobsBrawl.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/SuperSmashMobsBrawl.kt
@@ -12,6 +12,7 @@ import dev.betrix.superSmashMobsBrawl.services.HotbarService
 import dev.betrix.superSmashMobsBrawl.services.HubProtectionService
 import dev.betrix.superSmashMobsBrawl.services.HubService
 import dev.betrix.superSmashMobsBrawl.services.WorldService
+import dev.betrix.superSmashMobsBrawl.utils.mm
 import dev.rollczi.litecommands.LiteCommands
 import dev.rollczi.litecommands.bukkit.LiteBukkitFactory
 import gg.flyte.twilight.Twilight
@@ -40,6 +41,8 @@ class SuperSmashMobsBrawl : SuspendingJavaPlugin() {
         HubService.initialize(this)
         HubProtectionService.registerEvents()
         DebugService.initialize(this)
+
+        server.motd(mm("<gradient:#ff6b6b:#4ecdc4>⚔ <bold>SUPER SMASH MOBS BRAWL</bold> ⚔</gradient><newline><gradient:#ffd93d:#6bcf7f>\uD83C\uDFAE Choose Your Mob • Smash Enemies • Dominate! \uD83C\uDFC6</gradient>"))
 
         liteCommands =
             LiteBukkitFactory.builder(this)

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/abilities/instances/ExplosionAbilityInstance.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/abilities/instances/ExplosionAbilityInstance.kt
@@ -13,6 +13,7 @@ import dev.betrix.superSmashMobsBrawl.extensions.setVelocity
 import dev.betrix.superSmashMobsBrawl.utils.mm
 import gg.flyte.twilight.event.event
 import gg.flyte.twilight.extension.getNearbyEntities
+import gg.flyte.twilight.extension.resetWalkSpeed
 import gg.flyte.twilight.scheduler.repeatingTask
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
@@ -141,7 +142,7 @@ class ExplosionAbilityInstance(definition: AbilityDefinition, player: Player) :
     }
 
     private fun resetPlayerData() {
-        player.walkSpeed = 0.2f
+        player.resetWalkSpeed()
         player.level = 0
         player.exp = 0f
     }

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/extensions/list.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/extensions/list.kt
@@ -11,6 +11,10 @@ fun List<SpawnPoint>.getEquidistant(n: Int): List<SpawnPoint> {
         return emptyList()
     }
 
+    if (n == 1) {
+        return listOf(this[0])
+    }
+
     if (n >= size) {
         return this.toList()
     }

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/extensions/list.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/extensions/list.kt
@@ -4,7 +4,7 @@ import dev.betrix.superSmashMobsBrawl.maps.SpawnPoint
 import kotlin.math.roundToInt
 
 /**
- * Returns `n` equally spaces spawn points
+ * Returns `n` equally spaced spawn points
  */
 fun List<SpawnPoint>.getEquidistant(n: Int): List<SpawnPoint> {
     if (isEmpty() || n <= 0) {

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/extensions/list.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/extensions/list.kt
@@ -1,0 +1,27 @@
+package dev.betrix.superSmashMobsBrawl.extensions
+
+import dev.betrix.superSmashMobsBrawl.maps.SpawnPoint
+import kotlin.math.roundToInt
+
+/**
+ * Returns `n` equally spaces spawn points
+ */
+fun List<SpawnPoint>.getEquidistant(n: Int): List<SpawnPoint> {
+    if (isEmpty() || n <= 0) {
+        return emptyList()
+    }
+
+    if (n >= size) {
+        return this.toList()
+    }
+
+    val result = mutableListOf<SpawnPoint>()
+    val step = (size - 1).toDouble() / (n - 1)
+
+    for (i in 0 until n) {
+        val index = (i * step).roundToInt()
+        result.add(this[index])
+    }
+
+    return result
+}

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/MinigameState.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/MinigameState.kt
@@ -1,0 +1,8 @@
+package dev.betrix.superSmashMobsBrawl.minigames
+
+enum class MinigameState {
+    PREFLIGHT,
+    STARTING,
+    ONGOING,
+    ENDED
+}

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/definitions/TwoPlayerDuelsMinigameDefinition.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/definitions/TwoPlayerDuelsMinigameDefinition.kt
@@ -13,7 +13,7 @@ object TwoPlayerDuelsMinigameDefinition : MinigameDefinition() {
         description = "The most competitive game mode SSMB has to offer"
         isHidden = false
         playersPerTeam = 1
-        amountOfTeams = 1
+        amountOfTeams = 2
         stocks = 4
 
         whitelistMap("campsite")

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/definitions/TwoPlayerDuelsMinigameDefinition.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/definitions/TwoPlayerDuelsMinigameDefinition.kt
@@ -1,25 +1,26 @@
 package dev.betrix.superSmashMobsBrawl.minigames.definitions
 
 import dev.betrix.superSmashMobsBrawl.minigames.instances.MinigameInstance
-import dev.betrix.superSmashMobsBrawl.minigames.instances.TestingMinigameInstance
+import dev.betrix.superSmashMobsBrawl.minigames.instances.TwoPlayerDuelsMinigameInstance
 import dev.betrix.superSmashMobsBrawl.minigames.minigame
 import dev.betrix.superSmashMobsBrawl.models.MinigameTeam
 
-object TestingMinigameDefinition : MinigameDefinition() {
-    override val name = "Testing"
-    override val id = "testing"
+object TwoPlayerDuelsMinigameDefinition : MinigameDefinition() {
+    override val name = "1v1 Duels"
+    override val id = "two_player_duels"
 
     override val metadata = minigame {
-        description = "A simple testing minigame"
-        isHidden = true
+        description = "The most competitive game mode SSMB has to offer"
+        isHidden = false
         playersPerTeam = 1
         amountOfTeams = 1
-        allowKitSwitching = true
+        stocks = 4
 
         whitelistMap("campsite")
     }
 
     override fun createInstance(teams: List<MinigameTeam>): MinigameInstance {
-        return TestingMinigameInstance(this, teams)
+        return TwoPlayerDuelsMinigameInstance(this, teams)
     }
+
 }

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/instances/MinigameInstance.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/instances/MinigameInstance.kt
@@ -66,9 +66,7 @@ abstract class MinigameInstance(val definition: MinigameDefinition, val teams: L
         // Check if minigame should end and clean up
         if (shouldEndMinigame()) {
             SuperSmashMobsBrawl.instance.launch {
-                state = MinigameState.ENDED
                 onMinigameEnd()
-                teardownMinigame()
             }
         }
 

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/instances/MinigameInstance.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/instances/MinigameInstance.kt
@@ -1,24 +1,83 @@
 package dev.betrix.superSmashMobsBrawl.minigames.instances
 
+import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.onFailure
+import com.github.michaelbull.result.onSuccess
+import com.github.shynixn.mccoroutine.bukkit.launch
+import dev.betrix.superSmashMobsBrawl.Managable
+import dev.betrix.superSmashMobsBrawl.SuperSmashMobsBrawl
+import dev.betrix.superSmashMobsBrawl.minigames.MinigameState
 import dev.betrix.superSmashMobsBrawl.minigames.definitions.MinigameDefinition
 import dev.betrix.superSmashMobsBrawl.models.MinigameTeam
+import dev.betrix.superSmashMobsBrawl.registries.MapRegistry
+import dev.betrix.superSmashMobsBrawl.services.KitService
+import dev.betrix.superSmashMobsBrawl.services.WorldService
 import java.util.UUID
 import org.bukkit.World
 import org.bukkit.entity.Player
 
-abstract class MinigameInstance(val definition: MinigameDefinition, val teams: List<MinigameTeam>) {
+abstract class MinigameInstance(val definition: MinigameDefinition, val teams: List<MinigameTeam>): Managable() {
     open lateinit var world: World
-    val gameId: String = UUID.randomUUID().toString()
+        protected set
+    var state = MinigameState.PREFLIGHT
+        protected set
 
-    open suspend fun setup(): Result<Unit, Exception> {
+    val gameId = UUID.randomUUID().toString()
+    val map = MapRegistry.getValidMapsForMinigame(definition).random()
+
+    protected val players: List<Player>
+        get() = teams.flatMap { it.players }
+
+    open suspend fun initMinigame(): Result<Unit, Exception> {
+        try {
+            teams.forEach {
+                it.players.forEach { player ->
+                    if (!player.isOnline) {
+                        return Err(RuntimeException("A player is offline"))
+                    }
+                }
+            }
+
+            WorldService.copyAndLoadWorld(map, gameId)
+                .onFailure { return Err(it) }
+                .onSuccess { world = it.world }
+
+        } catch (e: Exception) {
+            return Err(e)
+        }
+
+        setupAsync()
         return Ok(Unit)
     }
 
-    open suspend fun teardown(): Unit {}
+    open suspend fun teardownMinigame() {
+        teardownAsync()
+    }
 
-    abstract fun onPlayerLeave(player: Player): Result<Unit, String>
+    open fun onPlayerLeave(player: Player): Result<Unit, String> {
+        // Remove the player from teams
+        teams.forEach { team -> team.players.remove(player) }
+
+        // Unassign kit
+        KitService.unassignKit(player)
+
+        // Check if minigame should end and clean up
+        if (shouldEndMinigame()) {
+            SuperSmashMobsBrawl.instance.launch {
+                state = MinigameState.ENDED
+                onMinigameEnd()
+                teardownMinigame()
+            }
+        }
+
+        return Ok(Unit)
+    }
+
+    open suspend fun onMinigameEnd() {}
+
+    protected abstract fun shouldEndMinigame(): Boolean
 
     fun isPlayerInMinigame(player: Player): Boolean {
         return teams.find { it.players.contains(player) } != null

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/instances/MinigameInstance.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/instances/MinigameInstance.kt
@@ -6,19 +6,20 @@ import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.onFailure
 import com.github.michaelbull.result.onSuccess
 import com.github.shynixn.mccoroutine.bukkit.launch
-import dev.betrix.superSmashMobsBrawl.Managable
+import dev.betrix.superSmashMobsBrawl.Manageable
 import dev.betrix.superSmashMobsBrawl.SuperSmashMobsBrawl
 import dev.betrix.superSmashMobsBrawl.minigames.MinigameState
 import dev.betrix.superSmashMobsBrawl.minigames.definitions.MinigameDefinition
 import dev.betrix.superSmashMobsBrawl.models.MinigameTeam
 import dev.betrix.superSmashMobsBrawl.registries.MapRegistry
+import dev.betrix.superSmashMobsBrawl.services.HubService
 import dev.betrix.superSmashMobsBrawl.services.KitService
 import dev.betrix.superSmashMobsBrawl.services.WorldService
 import java.util.UUID
 import org.bukkit.World
 import org.bukkit.entity.Player
 
-abstract class MinigameInstance(val definition: MinigameDefinition, val teams: List<MinigameTeam>): Managable() {
+abstract class MinigameInstance(val definition: MinigameDefinition, val teams: List<MinigameTeam>): Manageable() {
     open lateinit var world: World
         protected set
     var state = MinigameState.PREFLIGHT
@@ -50,6 +51,18 @@ abstract class MinigameInstance(val definition: MinigameDefinition, val teams: L
 
         setupAsync()
         return Ok(Unit)
+    }
+
+    override suspend fun teardownAsync() {
+        WorldService.deleteWorld(world).onFailure {
+            SuperSmashMobsBrawl.instance.logger.severe("Unable to delete world $world")
+        }
+
+        players.forEach { player ->
+            HubService.teleportToDefaultHub(player)
+        }
+
+        super.teardownAsync()
     }
 
     open suspend fun teardownMinigame() {

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/instances/TestingMinigameInstance.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/instances/TestingMinigameInstance.kt
@@ -4,6 +4,7 @@ import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.onFailure
+import dev.betrix.superSmashMobsBrawl.SuperSmashMobsBrawl
 import dev.betrix.superSmashMobsBrawl.minigames.definitions.MinigameDefinition
 import dev.betrix.superSmashMobsBrawl.models.MinigameTeam
 import dev.betrix.superSmashMobsBrawl.services.HubService
@@ -30,7 +31,7 @@ class TestingMinigameInstance(definition: MinigameDefinition, teams: List<Miniga
 
                 KitService.assignKit(player).onFailure { error ->
                     // Log error if kit assignment fails
-                    println("Failed to assign kit to ${player.name}: $error")
+                    SuperSmashMobsBrawl.instance.logger.warning("Failed to assign kit to ${player.name}: $error")
                 }
             }
         }

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/instances/TestingMinigameInstance.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/instances/TestingMinigameInstance.kt
@@ -3,12 +3,7 @@ package dev.betrix.superSmashMobsBrawl.minigames.instances
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
-import com.github.michaelbull.result.mapBoth
 import com.github.michaelbull.result.onFailure
-import com.github.shynixn.mccoroutine.bukkit.launch
-import dev.betrix.superSmashMobsBrawl.SuperSmashMobsBrawl
-import dev.betrix.superSmashMobsBrawl.kits.definitions.CreeperKitDefinition
-import dev.betrix.superSmashMobsBrawl.maps.campsiteMap
 import dev.betrix.superSmashMobsBrawl.minigames.definitions.MinigameDefinition
 import dev.betrix.superSmashMobsBrawl.models.MinigameTeam
 import dev.betrix.superSmashMobsBrawl.services.HubService
@@ -19,50 +14,31 @@ import dev.betrix.superSmashMobsBrawl.utils.createLocation
 import gg.flyte.twilight.extension.feed
 import gg.flyte.twilight.extension.heal
 import org.bukkit.World
-import org.bukkit.entity.Player
 
 class TestingMinigameInstance(definition: MinigameDefinition, teams: List<MinigameTeam>) :
     MinigameInstance(definition, teams) {
     override lateinit var world: World
 
-    private val players: List<Player>
-        get() = teams.flatMap { it.players }
+    override suspend fun initMinigame(): Result<Unit, Exception> {
+        super.initMinigame().onFailure { return Err(it) }
 
-    override suspend fun setup(): Result<Unit, Exception> {
-        try {
-            WorldService.copyAndLoadWorld(campsiteMap, gameId)
-                .mapBoth(
-                    failure = {
-                        return Err(it)
-                    },
-                    success = { loadedWorld ->
-                        this@TestingMinigameInstance.world = loadedWorld.world
+        teams.forEach { team ->
+            team.players.forEach { player ->
+                player.feed()
+                player.heal()
+                player.teleport(createLocation(world, map.spawnPoints[0]))
 
-                        players.forEach { player ->
-                            player.feed()
-                            player.heal()
-                            player.teleport(createLocation(world, campsiteMap.spawnPoints[0]))
-                        }
-                    },
-                )
-
-            // Assign kits to all players
-            teams.forEach { team ->
-                team.players.forEach { player ->
-                    KitService.assignKit(player, CreeperKitDefinition).onFailure { error ->
-                        // Log error if kit assignment fails
-                        println("Failed to assign kit to ${player.name}: $error")
-                    }
+                KitService.assignKit(player).onFailure { error ->
+                    // Log error if kit assignment fails
+                    println("Failed to assign kit to ${player.name}: $error")
                 }
             }
-
-            return Ok(Unit)
-        } catch (e: Exception) {
-            return Err(e)
         }
+
+        return Ok(Unit)
     }
 
-    override suspend fun teardown() {
+    override suspend fun teardownMinigame() {
         // Unassign kits from all players
         players.forEach { player ->
             HubService.teleportToDefaultHub(player)
@@ -73,22 +49,7 @@ class TestingMinigameInstance(definition: MinigameDefinition, teams: List<Miniga
         MinigameService.removeMinigameInstance(this)
     }
 
-    override fun onPlayerLeave(player: Player): Result<Unit, String> {
-        // Remove the player from teams
-        teams.forEach { team -> team.players.remove(player) }
-
-        // Unassign kit
-        KitService.unassignKit(player)
-
-        // Check if minigame should end and clean up
-        if (shouldEndMinigame()) {
-            SuperSmashMobsBrawl.instance.launch { teardown() }
-        }
-
-        return Ok(Unit)
-    }
-
-    private fun shouldEndMinigame(): Boolean {
+    override fun shouldEndMinigame(): Boolean {
         return players.isEmpty()
     }
 }

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/instances/TwoPlayerDuelsMinigameInstance.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/instances/TwoPlayerDuelsMinigameInstance.kt
@@ -295,8 +295,11 @@ class TwoPlayerDuelsMinigameInstance(definition: MinigameDefinition, teams: List
         KitService.assignKit(player).onFailure {
             when (it) {
                 AssignKitError.PLAYER_HAS_KIT -> {
+                    plugin.logger.warning("Player ${player.name} already had a kit during respawn, reassigning...")
                     KitService.unassignKit(player)
-                    KitService.assignKit(player)
+                    KitService.assignKit(player).onFailure { error ->
+                        plugin.logger.severe("Failed to reassign kit to ${player.name} during respawn: $error")
+                    }
                 }
             }
         }

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/instances/TwoPlayerDuelsMinigameInstance.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/instances/TwoPlayerDuelsMinigameInstance.kt
@@ -35,6 +35,7 @@ import org.bukkit.entity.Player
 import org.bukkit.event.entity.PlayerDeathEvent
 import org.bukkit.util.Vector
 import java.time.Duration
+import java.util.Collections
 import kotlin.time.Duration.Companion.seconds
 
 class TwoPlayerDuelsMinigameInstance(definition: MinigameDefinition, teams: List<MinigameTeam>): MinigameInstance(definition, teams) {
@@ -45,7 +46,7 @@ class TwoPlayerDuelsMinigameInstance(definition: MinigameDefinition, teams: List
     private val spectatorHeightAboveSpawn = 50.0
     
     // Track dead players to prevent multiple death events
-    private val deadPlayers = mutableSetOf<Player>()
+    private val deadPlayers = Collections.synchronizedSet(mutableSetOf<Player>())
 
     override suspend fun initMinigame(): Result<Unit, Exception> {
         super.initMinigame().onFailure { return Err(it) }
@@ -102,7 +103,15 @@ class TwoPlayerDuelsMinigameInstance(definition: MinigameDefinition, teams: List
     }
 
     override fun shouldEndMinigame(): Boolean {
+        if (teams.isEmpty()) {
+            return true
+        }
+
         teams.forEach {
+            if (it.stocks == 0) {
+                return true
+            }
+
             if (it.players.isEmpty()) {
                 return true
             }
@@ -112,9 +121,14 @@ class TwoPlayerDuelsMinigameInstance(definition: MinigameDefinition, teams: List
     }
 
     override suspend fun onMinigameEnd() {
+        if (teams.isEmpty()) {
+            super.onMinigameEnd()
+            teardownMinigame()
+        }
+
         state = MinigameState.ENDED
 
-        val winningTeam = teams.first { it.stocks > 0 }
+        val winningTeam = teams.find { it.stocks > 0 } ?: teams.find { !it.players.isEmpty() } ?: teams.first()
 
         winningTeam.players.forEach {
             it.sendMessage("You won!")
@@ -214,7 +228,9 @@ class TwoPlayerDuelsMinigameInstance(definition: MinigameDefinition, teams: List
         val playerTeam = teams.find { it.players.contains(player) }
 
         // Reduce team stocks
-        playerTeam?.stocks--
+        if (playerTeam != null) {
+            playerTeam.stocks--
+        }
         
         // Set player to spectator mode
         player.gameMode = GameMode.SPECTATOR

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/instances/TwoPlayerDuelsMinigameInstance.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/instances/TwoPlayerDuelsMinigameInstance.kt
@@ -64,7 +64,8 @@ class TwoPlayerDuelsMinigameInstance(definition: MinigameDefinition, teams: List
                 player.flySpeed = 0f
                 player.velocity = Vector(0, 0, 0)
 
-                player.teleport(createLocation(world, spawnPoints[(teamIdx + 1) * playerIdx]))
+                val playerNumber = teamIdx * definition.metadata.playersPerTeam + playerIdx
+                player.teleport(createLocation(world, spawnPoints[playerNumber]))
 
                 KitService.assignKit(player).onFailure {
                     when (it) {
@@ -82,6 +83,7 @@ class TwoPlayerDuelsMinigameInstance(definition: MinigameDefinition, teams: List
 
         players.forEach { player ->
             player.resetWalkSpeed()
+            player.resetFlySpeed()
         }
 
         state = MinigameState.ONGOING
@@ -121,12 +123,15 @@ class TwoPlayerDuelsMinigameInstance(definition: MinigameDefinition, teams: List
     }
 
     override suspend fun onMinigameEnd() {
+        state = MinigameState.ENDED
+
         if (teams.isEmpty()) {
             super.onMinigameEnd()
             teardownMinigame()
+
+            return
         }
 
-        state = MinigameState.ENDED
 
         val winningTeam = teams.find { it.stocks > 0 } ?: teams.find { !it.players.isEmpty() } ?: teams.first()
 
@@ -144,7 +149,7 @@ class TwoPlayerDuelsMinigameInstance(definition: MinigameDefinition, teams: List
                 playPingSound()
 
                 val title = Title.title(
-                    mm("<green>${iteration + 1}</green>"),
+                    mm("<green>${countdownSeconds - iteration}</green>"),
                     mm("<gray>Game starting in</gray>"),
                     Title.Times.times(
                         Duration.ofMillis(250),

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/instances/TwoPlayerDuelsMinigameInstance.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/instances/TwoPlayerDuelsMinigameInstance.kt
@@ -4,9 +4,12 @@ import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.onFailure
+import com.github.shynixn.mccoroutine.bukkit.launch
 import com.github.shynixn.mccoroutine.bukkit.minecraftDispatcher
 import dev.betrix.superSmashMobsBrawl.SuperSmashMobsBrawl
+import dev.betrix.superSmashMobsBrawl.events.SmashDamageEvent
 import dev.betrix.superSmashMobsBrawl.extensions.getEquidistant
+import dev.betrix.superSmashMobsBrawl.maps.SpawnPoint
 import dev.betrix.superSmashMobsBrawl.minigames.MinigameState
 import dev.betrix.superSmashMobsBrawl.minigames.definitions.MinigameDefinition
 import dev.betrix.superSmashMobsBrawl.models.MinigameTeam
@@ -14,25 +17,37 @@ import dev.betrix.superSmashMobsBrawl.services.AssignKitError
 import dev.betrix.superSmashMobsBrawl.services.KitService
 import dev.betrix.superSmashMobsBrawl.utils.createLocation
 import dev.betrix.superSmashMobsBrawl.utils.mm
+import gg.flyte.twilight.event.event
 import gg.flyte.twilight.extension.feed
 import gg.flyte.twilight.extension.heal
 import gg.flyte.twilight.extension.resetFlySpeed
 import gg.flyte.twilight.extension.resetWalkSpeed
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.title.Title
 import org.bukkit.GameMode
+import org.bukkit.Location
 import org.bukkit.Sound
+import org.bukkit.entity.Player
+import org.bukkit.event.entity.PlayerDeathEvent
 import org.bukkit.util.Vector
 import java.time.Duration
+import kotlin.math.pow
+import kotlin.math.sqrt
 import kotlin.time.Duration.Companion.seconds
 
 class TwoPlayerDuelsMinigameInstance(definition: MinigameDefinition, teams: List<MinigameTeam>): MinigameInstance(definition, teams) {
     private val plugin = SuperSmashMobsBrawl.instance
 
     private val countdownSeconds = 5
+    private val deathSpectatorSeconds = 5
+    private val spectatorHeightAboveSpawn = 50.0
+    
+    // Track dead players to prevent multiple death events
+    private val deadPlayers = mutableSetOf<Player>()
 
     override suspend fun initMinigame(): Result<Unit, Exception> {
         super.initMinigame().onFailure { return Err(it) }
@@ -60,6 +75,8 @@ class TwoPlayerDuelsMinigameInstance(definition: MinigameDefinition, teams: List
             }
         }
 
+        setupEventListeners()
+
         state = MinigameState.STARTING
 
         doCountdown()
@@ -81,6 +98,9 @@ class TwoPlayerDuelsMinigameInstance(definition: MinigameDefinition, teams: List
             player.resetWalkSpeed()
             KitService.unassignKit(player)
         }
+        
+        // Clear dead players set
+        deadPlayers.clear()
     }
 
     override fun shouldEndMinigame(): Boolean {
@@ -140,5 +160,147 @@ class TwoPlayerDuelsMinigameInstance(definition: MinigameDefinition, teams: List
         players.forEach { player ->
             player.playSound(player.location, Sound.ENTITY_EXPERIENCE_ORB_PICKUP, 1f, 1f)
         }
+    }
+    
+    private fun setupEventListeners() {
+        // Listen for SmashDamageEvent to apply damage and handle deaths
+        event<SmashDamageEvent> {
+            if (!isValid(this@TwoPlayerDuelsMinigameInstance)) return@event
+            if (state != MinigameState.ONGOING) return@event
+            
+            val player = victim as? Player ?: return@event
+            if (deadPlayers.contains(player)) return@event
+            
+            // Apply damage to the player
+            val newHealth = (player.health - damage).coerceAtLeast(0.0)
+            player.health = newHealth
+            
+            // Apply knockback
+            if (knockbackMultiplier > 0.0 && damager is dev.betrix.superSmashMobsBrawl.events.Damager.LivingEntity) {
+                val damagerEntity = damager.livingEntity
+                val direction = player.location.toVector().subtract(damagerEntity.location.toVector()).normalize()
+                val knockback = direction.multiply(knockbackMultiplier)
+                player.velocity = player.velocity.add(knockback)
+            }
+            
+            // Check if player should die
+            if (newHealth <= 0.0) {
+                handlePlayerDeath(player)
+            }
+        }
+        
+        // Listen for PlayerDeathEvent to handle the death loop
+        event<PlayerDeathEvent> {
+            val player = player
+            if (!isPlayerInMinigame(player)) return@event
+            if (state != MinigameState.ONGOING) return@event
+            
+            // Cancel the default death behavior
+            isCancelled = true
+            
+            handlePlayerDeath(player)
+        }
+    }
+    
+    private fun handlePlayerDeath(player: Player) {
+        if (deadPlayers.contains(player)) return
+        deadPlayers.add(player)
+        
+        // Find the team this player belongs to
+        val playerTeam = teams.find { it.players.contains(player) } ?: return
+        
+        // Reduce team stocks
+        playerTeam.stocks--
+        
+        // Set player to spectator mode
+        player.gameMode = GameMode.SPECTATOR
+        
+        // Remove kit and clear inventory
+        KitService.unassignKit(player)
+        player.inventory.clear()
+        
+        // Teleport to spectator position (50 blocks above a random spawn point)
+        val randomSpawnPoint = map.spawnPoints.random()
+        val spectatorLocation = createLocation(world, randomSpawnPoint).apply {
+            y += spectatorHeightAboveSpawn
+        }
+        player.teleport(spectatorLocation)
+        
+        // Send death message
+        player.sendMessage(mm("<red>You died! Respawning in $deathSpectatorSeconds seconds...</red>"))
+        
+        // Check if game should end after stock reduction
+        if (shouldEndMinigame()) {
+            SuperSmashMobsBrawl.instance.launch {
+                state = MinigameState.ENDED
+                onMinigameEnd()
+                teardownMinigame()
+            }
+            return
+        }
+        
+        // Start respawn timer
+        SuperSmashMobsBrawl.instance.launch {
+            withContext(plugin.minecraftDispatcher) {
+                delay(deathSpectatorSeconds.seconds)
+                
+                // Only respawn if player is still in the minigame and game is ongoing
+                if (isPlayerInMinigame(player) && state == MinigameState.ONGOING) {
+                    respawnPlayer(player)
+                }
+            }
+        }
+    }
+    
+    private suspend fun respawnPlayer(player: Player) {
+        // Remove from dead players set
+        deadPlayers.remove(player)
+        
+        // Find the furthest spawn point from enemy players
+        val furthestSpawnPoint = findFurthestSpawnPointFromEnemies(player)
+        
+        // Teleport to respawn location
+        player.teleport(createLocation(world, furthestSpawnPoint))
+        
+        // Reset player state
+        player.gameMode = GameMode.SURVIVAL
+        @Suppress("DEPRECATION")
+        player.health = player.maxHealth
+        player.feed()
+        player.heal()
+        
+        // Reassign kit
+        KitService.assignKit(player)
+        
+        // Send respawn message
+        player.sendMessage(mm("<green>You have respawned!</green>"))
+    }
+    
+    private fun findFurthestSpawnPointFromEnemies(respawningPlayer: Player): SpawnPoint {
+        // Get all enemy players (players not on the same team)
+        val respawningPlayerTeam = teams.find { it.players.contains(respawningPlayer) }
+        val enemyPlayers = teams.filter { it != respawningPlayerTeam }
+            .flatMap { it.players }
+            .filter { !deadPlayers.contains(it) } // Only consider alive enemies
+        
+        if (enemyPlayers.isEmpty()) {
+            // If no enemies are alive, return any spawn point
+            return map.spawnPoints.random()
+        }
+        
+        // Calculate the spawn point with maximum distance from all enemies
+        return map.spawnPoints.maxByOrNull { spawnPoint ->
+            val spawnLocation = createLocation(world, spawnPoint)
+            enemyPlayers.minOfOrNull { enemy ->
+                calculateDistance(spawnLocation, enemy.location)
+            } ?: Double.MAX_VALUE
+        } ?: map.spawnPoints.random()
+    }
+    
+    private fun calculateDistance(loc1: Location, loc2: Location): Double {
+        val deltaX = loc1.x - loc2.x
+        val deltaY = loc1.y - loc2.y
+        val deltaZ = loc1.z - loc2.z
+        return sqrt(deltaX.pow(2) + deltaY.pow(2) + deltaZ.pow(2))
     }
 }

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/instances/TwoPlayerDuelsMinigameInstance.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/instances/TwoPlayerDuelsMinigameInstance.kt
@@ -4,6 +4,7 @@ import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.onFailure
+import com.github.shynixn.mccoroutine.bukkit.asyncDispatcher
 import com.github.shynixn.mccoroutine.bukkit.launch
 import com.github.shynixn.mccoroutine.bukkit.minecraftDispatcher
 import dev.betrix.superSmashMobsBrawl.SuperSmashMobsBrawl
@@ -24,19 +25,16 @@ import gg.flyte.twilight.extension.resetFlySpeed
 import gg.flyte.twilight.extension.resetWalkSpeed
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import net.kyori.adventure.audience.Audience
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.title.Title
 import org.bukkit.GameMode
-import org.bukkit.Location
 import org.bukkit.Sound
 import org.bukkit.entity.Player
 import org.bukkit.event.entity.PlayerDeathEvent
 import org.bukkit.util.Vector
 import java.time.Duration
-import kotlin.math.pow
-import kotlin.math.sqrt
 import kotlin.time.Duration.Companion.seconds
 
 class TwoPlayerDuelsMinigameInstance(definition: MinigameDefinition, teams: List<MinigameTeam>): MinigameInstance(definition, teams) {
@@ -114,6 +112,8 @@ class TwoPlayerDuelsMinigameInstance(definition: MinigameDefinition, teams: List
     }
 
     override suspend fun onMinigameEnd() {
+        state = MinigameState.ENDED
+
         val winningTeam = teams.first { it.stocks > 0 }
 
         winningTeam.players.forEach {
@@ -121,6 +121,7 @@ class TwoPlayerDuelsMinigameInstance(definition: MinigameDefinition, teams: List
         }
 
         super.onMinigameEnd()
+        teardownMinigame()
     }
 
     private suspend fun doCountdown() {
@@ -164,17 +165,17 @@ class TwoPlayerDuelsMinigameInstance(definition: MinigameDefinition, teams: List
     
     private fun setupEventListeners() {
         // Listen for SmashDamageEvent to apply damage and handle deaths
-        event<SmashDamageEvent> {
+        listeners.add(event<SmashDamageEvent> {
             if (!isValid(this@TwoPlayerDuelsMinigameInstance)) return@event
             if (state != MinigameState.ONGOING) return@event
-            
+
             val player = victim as? Player ?: return@event
             if (deadPlayers.contains(player)) return@event
-            
+
             // Apply damage to the player
             val newHealth = (player.health - damage).coerceAtLeast(0.0)
             player.health = newHealth
-            
+
             // Apply knockback
             if (knockbackMultiplier > 0.0 && damager is dev.betrix.superSmashMobsBrawl.events.Damager.LivingEntity) {
                 val damagerEntity = damager.livingEntity
@@ -182,35 +183,38 @@ class TwoPlayerDuelsMinigameInstance(definition: MinigameDefinition, teams: List
                 val knockback = direction.multiply(knockbackMultiplier)
                 player.velocity = player.velocity.add(knockback)
             }
-            
+
             // Check if player should die
             if (newHealth <= 0.0) {
                 handlePlayerDeath(player)
             }
-        }
+        })
         
         // Listen for PlayerDeathEvent to handle the death loop
-        event<PlayerDeathEvent> {
+        listeners.add(event<PlayerDeathEvent> {
             val player = player
             if (!isPlayerInMinigame(player)) return@event
             if (state != MinigameState.ONGOING) return@event
-            
+
             // Cancel the default death behavior
             isCancelled = true
-            
+
             handlePlayerDeath(player)
-        }
+        })
     }
     
     private fun handlePlayerDeath(player: Player) {
         if (deadPlayers.contains(player)) return
         deadPlayers.add(player)
+
+        // Lightning strike to match other ssm versions
+        world.strikeLightningEffect(player.location)
         
         // Find the team this player belongs to
-        val playerTeam = teams.find { it.players.contains(player) } ?: return
-        
+        val playerTeam = teams.find { it.players.contains(player) }
+
         // Reduce team stocks
-        playerTeam.stocks--
+        playerTeam?.stocks--
         
         // Set player to spectator mode
         player.gameMode = GameMode.SPECTATOR
@@ -225,25 +229,35 @@ class TwoPlayerDuelsMinigameInstance(definition: MinigameDefinition, teams: List
             y += spectatorHeightAboveSpawn
         }
         player.teleport(spectatorLocation)
-        
-        // Send death message
-        player.sendMessage(mm("<red>You died! Respawning in $deathSpectatorSeconds seconds...</red>"))
+
+        // Send death message and title
+        val deathTitle = Title.title(
+            mm("<red>You Died</red>"),
+            Component.empty(),
+            Title.Times.times(
+                Duration.ofMillis(0),
+                Duration.ofMillis(750),
+                Duration.ofMillis(250)
+            ))
+
+        Audience.audience(player).showTitle(deathTitle)
+        player.sendMessage(mm("<red>Respawning in $deathSpectatorSeconds seconds...</red>"))
         
         // Check if game should end after stock reduction
         if (shouldEndMinigame()) {
             SuperSmashMobsBrawl.instance.launch {
-                state = MinigameState.ENDED
                 onMinigameEnd()
-                teardownMinigame()
             }
             return
         }
         
         // Start respawn timer
         SuperSmashMobsBrawl.instance.launch {
-            withContext(plugin.minecraftDispatcher) {
+            withContext(plugin.asyncDispatcher) {
                 delay(deathSpectatorSeconds.seconds)
-                
+            }
+
+            withContext(plugin.minecraftDispatcher) {
                 // Only respawn if player is still in the minigame and game is ongoing
                 if (isPlayerInMinigame(player) && state == MinigameState.ONGOING) {
                     respawnPlayer(player)
@@ -252,26 +266,31 @@ class TwoPlayerDuelsMinigameInstance(definition: MinigameDefinition, teams: List
         }
     }
     
-    private suspend fun respawnPlayer(player: Player) {
+    private fun respawnPlayer(player: Player) {
         // Remove from dead players set
         deadPlayers.remove(player)
-        
+
+        // Reassign kit
+        KitService.assignKit(player).onFailure {
+            when (it) {
+                AssignKitError.PLAYER_HAS_KIT -> {
+                    KitService.unassignKit(player)
+                    KitService.assignKit(player)
+                }
+            }
+        }
+
         // Find the furthest spawn point from enemy players
         val furthestSpawnPoint = findFurthestSpawnPointFromEnemies(player)
-        
+
         // Teleport to respawn location
         player.teleport(createLocation(world, furthestSpawnPoint))
         
         // Reset player state
         player.gameMode = GameMode.SURVIVAL
-        @Suppress("DEPRECATION")
-        player.health = player.maxHealth
         player.feed()
         player.heal()
-        
-        // Reassign kit
-        KitService.assignKit(player)
-        
+
         // Send respawn message
         player.sendMessage(mm("<green>You have respawned!</green>"))
     }
@@ -279,28 +298,22 @@ class TwoPlayerDuelsMinigameInstance(definition: MinigameDefinition, teams: List
     private fun findFurthestSpawnPointFromEnemies(respawningPlayer: Player): SpawnPoint {
         // Get all enemy players (players not on the same team)
         val respawningPlayerTeam = teams.find { it.players.contains(respawningPlayer) }
-        val enemyPlayers = teams.filter { it != respawningPlayerTeam }
+        val enemyPlayers = teams
+            .filter { it != respawningPlayerTeam }
             .flatMap { it.players }
             .filter { !deadPlayers.contains(it) } // Only consider alive enemies
-        
+
         if (enemyPlayers.isEmpty()) {
             // If no enemies are alive, return any spawn point
             return map.spawnPoints.random()
         }
-        
+
         // Calculate the spawn point with maximum distance from all enemies
         return map.spawnPoints.maxByOrNull { spawnPoint ->
             val spawnLocation = createLocation(world, spawnPoint)
             enemyPlayers.minOfOrNull { enemy ->
-                calculateDistance(spawnLocation, enemy.location)
+                spawnLocation.distance(enemy.location)
             } ?: Double.MAX_VALUE
         } ?: map.spawnPoints.random()
-    }
-    
-    private fun calculateDistance(loc1: Location, loc2: Location): Double {
-        val deltaX = loc1.x - loc2.x
-        val deltaY = loc1.y - loc2.y
-        val deltaZ = loc1.z - loc2.z
-        return sqrt(deltaX.pow(2) + deltaY.pow(2) + deltaZ.pow(2))
     }
 }

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/instances/TwoPlayerDuelsMinigameInstance.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/instances/TwoPlayerDuelsMinigameInstance.kt
@@ -1,0 +1,144 @@
+package dev.betrix.superSmashMobsBrawl.minigames.instances
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.onFailure
+import com.github.shynixn.mccoroutine.bukkit.minecraftDispatcher
+import dev.betrix.superSmashMobsBrawl.SuperSmashMobsBrawl
+import dev.betrix.superSmashMobsBrawl.extensions.getEquidistant
+import dev.betrix.superSmashMobsBrawl.minigames.MinigameState
+import dev.betrix.superSmashMobsBrawl.minigames.definitions.MinigameDefinition
+import dev.betrix.superSmashMobsBrawl.models.MinigameTeam
+import dev.betrix.superSmashMobsBrawl.services.AssignKitError
+import dev.betrix.superSmashMobsBrawl.services.KitService
+import dev.betrix.superSmashMobsBrawl.utils.createLocation
+import dev.betrix.superSmashMobsBrawl.utils.mm
+import gg.flyte.twilight.extension.feed
+import gg.flyte.twilight.extension.heal
+import gg.flyte.twilight.extension.resetFlySpeed
+import gg.flyte.twilight.extension.resetWalkSpeed
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.title.Title
+import org.bukkit.GameMode
+import org.bukkit.Sound
+import org.bukkit.util.Vector
+import java.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+class TwoPlayerDuelsMinigameInstance(definition: MinigameDefinition, teams: List<MinigameTeam>): MinigameInstance(definition, teams) {
+    private val plugin = SuperSmashMobsBrawl.instance
+
+    private val countdownSeconds = 5
+
+    override suspend fun initMinigame(): Result<Unit, Exception> {
+        super.initMinigame().onFailure { return Err(it) }
+
+        val spawnPoints = map.spawnPoints.getEquidistant(players.size)
+
+        teams.forEachIndexed { teamIdx, team ->
+            team.players.forEachIndexed { playerIdx, player  ->
+                player.feed()
+                player.heal()
+                player.gameMode = GameMode.SURVIVAL
+
+                // Freeze player
+                player.walkSpeed = 0f
+                player.flySpeed = 0f
+                player.velocity = Vector(0, 0, 0)
+
+                player.teleport(createLocation(world, spawnPoints[(teamIdx + 1) * playerIdx]))
+
+                KitService.assignKit(player).onFailure {
+                    when (it) {
+                        AssignKitError.PLAYER_HAS_KIT -> return Err(RuntimeException("Player $player already has a kit assigned to them"))
+                    }
+                }
+            }
+        }
+
+        state = MinigameState.STARTING
+
+        doCountdown()
+
+        players.forEach { player ->
+            player.resetWalkSpeed()
+        }
+
+        state = MinigameState.ONGOING
+
+        return Ok(Unit)
+    }
+
+    override suspend fun teardownMinigame() {
+        super.teardownMinigame()
+
+        players.forEach { player ->
+            player.resetFlySpeed()
+            player.resetWalkSpeed()
+            KitService.unassignKit(player)
+        }
+    }
+
+    override fun shouldEndMinigame(): Boolean {
+        teams.forEach {
+            if (it.players.isEmpty()) {
+                return true
+            }
+        }
+
+        return false
+    }
+
+    override suspend fun onMinigameEnd() {
+        val winningTeam = teams.first { it.stocks > 0 }
+
+        winningTeam.players.forEach {
+            it.sendMessage("You won!")
+        }
+
+        super.onMinigameEnd()
+    }
+
+    private suspend fun doCountdown() {
+        withContext(plugin.minecraftDispatcher) {
+            repeat(countdownSeconds) { iteration ->
+                playPingSound()
+
+                val title = Title.title(
+                    mm("<green>${iteration + 1}</green>"),
+                    mm("<gray>Game starting in</gray>"),
+                    Title.Times.times(
+                        Duration.ofMillis(250),
+                        Duration.ofMillis(500),
+                        Duration.ofMillis(250),
+                    )
+                )
+
+                world.showTitle(title)
+
+                withContext(Dispatchers.IO) {
+                    delay(1.seconds)
+                }
+            }
+
+            playPingSound()
+
+            val startTitle = Title.title(
+                mm("<green>Go!</green>"),
+                Component.empty()
+            )
+
+            world.showTitle(startTitle)
+        }
+    }
+
+    private fun playPingSound() {
+        players.forEach { player ->
+            player.playSound(player.location, Sound.ENTITY_EXPERIENCE_ORB_PICKUP, 1f, 1f)
+        }
+    }
+}

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/metadata.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/metadata.kt
@@ -7,6 +7,8 @@ data class MinigameMetadata(
     val amountOfTeams: Int,
     val mapWhitelist: Set<String> = setOf(),
     val mapBlackList: Set<String> = setOf(),
+    val allowKitSwitching: Boolean = false,
+    val stocks: Int = 4,
 )
 
 class Minigame {
@@ -16,6 +18,8 @@ class Minigame {
     private var mapBlackList = hashSetOf<String>()
     var playersPerTeam: Int? = null
     var amountOfTeams: Int? = null
+    var allowKitSwitching = false
+    var stocks = 4
 
     fun whitelistMap(mapId: String): Minigame {
         require(!mapBlackList.contains(mapId)) {
@@ -59,6 +63,8 @@ class Minigame {
             mapWhitelist = mapWhiteList.toSet(),
             playersPerTeam = playersPerTeam!!,
             amountOfTeams = amountOfTeams!!,
+            allowKitSwitching = allowKitSwitching,
+            stocks = stocks,
         )
     }
 }

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/models/MinigameTeam.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/models/MinigameTeam.kt
@@ -2,4 +2,4 @@ package dev.betrix.superSmashMobsBrawl.models
 
 import org.bukkit.entity.Player
 
-data class MinigameTeam(val players: MutableList<Player>)
+data class MinigameTeam(val players: MutableList<Player>, var stocks: Int)

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/registries/MapRegistry.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/registries/MapRegistry.kt
@@ -38,19 +38,19 @@ object MapRegistry {
         val playerCount = definition.metadata.playersPerTeam * definition.metadata.amountOfTeams
 
         return maps.filter { (mapId, map) ->
-            if (map.maxPlayers == null || map.maxPlayers < playerCount || map.spawnPoints.size < playerCount) {
-                false
-            }
+            // Check player capacity and spawn points
+            if (map.maxPlayers != null && map.maxPlayers < playerCount) return@filter false
+            if (map.spawnPoints.size < playerCount) return@filter false
 
-            if (definition.metadata.mapBlackList.contains(mapId)) {
-                false
-            }
+            // Check blacklist
+            if (definition.metadata.mapBlackList.contains(mapId)) return@filter false
 
-            if (definition.metadata.mapWhitelist.contains(mapId)) {
+            // Check whitelist - if whitelist exists, map must be in it
+            if (definition.metadata.mapWhitelist.isNotEmpty()) {
+                definition.metadata.mapWhitelist.contains(mapId)
+            } else {
                 true
             }
-
-            definition.metadata.mapWhitelist.isEmpty()
         }.values.toList()
     }
 

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/registries/MapRegistry.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/registries/MapRegistry.kt
@@ -4,6 +4,7 @@ import dev.betrix.superSmashMobsBrawl.maps.MapType
 import dev.betrix.superSmashMobsBrawl.maps.SsmbMap
 import dev.betrix.superSmashMobsBrawl.maps.blueForestHub
 import dev.betrix.superSmashMobsBrawl.maps.campsiteMap
+import dev.betrix.superSmashMobsBrawl.minigames.definitions.MinigameDefinition
 
 object MapRegistry {
     private val maps = mutableMapOf<String, SsmbMap>()
@@ -33,8 +34,24 @@ object MapRegistry {
         return maps.values.find { it.id.contains(id, ignoreCase = true) }
     }
 
-    fun getValidMapForPlayerCount(playerCount: Int): SsmbMap {
-        TODO("Implement this function")
+    fun getValidMapsForMinigame(definition: MinigameDefinition): List<SsmbMap> {
+        val playerCount = definition.metadata.playersPerTeam * definition.metadata.amountOfTeams
+
+        return maps.filter { (mapId, map) ->
+            if (map.maxPlayers == null || map.maxPlayers < playerCount || map.spawnPoints.size < playerCount) {
+                false
+            }
+
+            if (definition.metadata.mapBlackList.contains(mapId)) {
+                false
+            }
+
+            if (definition.metadata.mapWhitelist.contains(mapId)) {
+                true
+            }
+
+            definition.metadata.mapWhitelist.isEmpty()
+        }.values.toList()
     }
 
     fun getHubMaps(): List<SsmbMap> {
@@ -43,10 +60,6 @@ object MapRegistry {
 
     fun getDefaultHub(): SsmbMap? {
         return maps["blue_forest"]
-    }
-
-    fun isHubMap(mapId: String): Boolean {
-        return maps[mapId]?.type == MapType.HUB
     }
 
     init {

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/registries/MinigameRegistry.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/registries/MinigameRegistry.kt
@@ -2,6 +2,7 @@ package dev.betrix.superSmashMobsBrawl.registries
 
 import dev.betrix.superSmashMobsBrawl.minigames.definitions.MinigameDefinition
 import dev.betrix.superSmashMobsBrawl.minigames.definitions.TestingMinigameDefinition
+import dev.betrix.superSmashMobsBrawl.minigames.definitions.TwoPlayerDuelsMinigameDefinition
 
 object MinigameRegistry {
     private val definitions = mutableMapOf<String, MinigameDefinition>()
@@ -35,5 +36,6 @@ object MinigameRegistry {
 
     init {
         register(TestingMinigameDefinition)
+        register(TwoPlayerDuelsMinigameDefinition)
     }
 }

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/KitService.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/KitService.kt
@@ -3,6 +3,7 @@ package dev.betrix.superSmashMobsBrawl.services
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
+import dev.betrix.superSmashMobsBrawl.kits.definitions.CreeperKitDefinition
 import dev.betrix.superSmashMobsBrawl.kits.definitions.KitDefinition
 import dev.betrix.superSmashMobsBrawl.kits.instances.KitInstance
 import org.bukkit.entity.Player
@@ -12,7 +13,20 @@ enum class AssignKitError {
 }
 
 object KitService {
+    private val playerSelectedKits = hashMapOf<Player, KitDefinition>()
     private val assignedKits = hashMapOf<Player, KitInstance>()
+
+    fun playerSelectKit(player: Player, kitDefinition: KitDefinition) {
+        playerSelectedKits[player] = kitDefinition
+    }
+
+    fun assignKit(player: Player): Result<KitInstance, AssignKitError> {
+        if (!playerSelectedKits.containsKey(player) && playerSelectedKits[player] != null) {
+            playerSelectedKits[player] = CreeperKitDefinition // Default kit for now
+        }
+
+        return assignKit(player, playerSelectedKits[player]!!)
+    }
 
     fun assignKit(
         player: Player,
@@ -25,7 +39,7 @@ object KitService {
         val kitInstance = kitDefinition.createInstance(player)
         assignedKits[player] = kitInstance
 
-        // Setup the kit (which will also setup hotbar items)
+        // Set up the kit (which will also set up hotbar items)
         kitInstance.setup()
 
         return Ok(kitInstance)

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/KitService.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/KitService.kt
@@ -21,11 +21,11 @@ object KitService {
     }
 
     fun assignKit(player: Player): Result<KitInstance, AssignKitError> {
-        if (!playerSelectedKits.containsKey(player) && playerSelectedKits[player] != null) {
+        if (!playerSelectedKits.containsKey(player) || playerSelectedKits[player] == null) {
             playerSelectedKits[player] = CreeperKitDefinition // Default kit for now
         }
 
-        return assignKit(player, playerSelectedKits[player]!!)
+        return assignKit(player, playerSelectedKits[player] ?: CreeperKitDefinition)
     }
 
     fun assignKit(

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/MinigameService.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/MinigameService.kt
@@ -48,7 +48,7 @@ object MinigameService {
 
     fun handleMinigameSetup(minigameInstance: MinigameInstance) {
         SuperSmashMobsBrawl.instance.launch {
-            minigameInstance.setup().onFailure { minigameInstance.teardown() }
+            minigameInstance.initMinigame().onFailure { minigameInstance.teardownMinigame() }
         }
     }
 

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/QueueService.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/QueueService.kt
@@ -105,7 +105,7 @@ object QueueService {
         // Split into teams
         val teams =
             entriesToUse.chunked(playersPerTeam).map { chunk ->
-                MinigameTeam(chunk.map { it.player }.toMutableList())
+                MinigameTeam(chunk.map { it.player }.toMutableList(), minigameDefinition.metadata.stocks)
             }
 
         // Remove these players from the queue

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/WorldService.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/WorldService.kt
@@ -174,6 +174,9 @@ object WorldService {
 
     private fun setupWorld(world: World, map: SsmbMap) {
         world.worldBorder.size = map.worldBorderSize
+        world.setStorm(false)
+        world.isVoidDamageEnabled = false
+        world.time = 5000L
         world.setGameRule(GameRule.DO_DAYLIGHT_CYCLE, false)
         world.setGameRule(GameRule.DO_WEATHER_CYCLE, false)
         world.setGameRule(GameRule.DO_MOB_SPAWNING, false)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new "1v1 Duels" minigame with custom rules, stocks, and map selection.
  * Added support for tracking and managing team stocks (lives) in minigames.
  * Players can now select kits, and kits are assigned based on their selection with a default fallback.
  * New minigame lifecycle management enables improved initialization, teardown, and state transitions.
  * Added new utility for selecting equidistant spawn points.
  * Server MOTD is now styled with a bold, colorful message.

* **Improvements**
  * Minigames now support configurable options such as allowing kit switching and custom stock counts.
  * Enhanced world setup for minigames, including disabling storms, void damage, and setting world time.
  * Minigame and map selection logic refined for better player experience and compatibility.

* **Bug Fixes**
  * Improved player speed reset handling for abilities.

* **Other**
  * Testing minigame is now hidden from public view.
  * Documentation and internal refactoring for better maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->