### PR TITLE
Fix leave command and end minigame

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 .turbo
+
+plugin/.gradle/**

--- a/plugin/.gradle/buildOutputCleanup/cache.properties
+++ b/plugin/.gradle/buildOutputCleanup/cache.properties
@@ -1,2 +1,2 @@
-#Sat Aug 02 02:53:19 UTC 2025
+#Sat Aug 02 22:27:46 UTC 2025
 gradle.version=8.11

--- a/plugin/.gradle/buildOutputCleanup/cache.properties
+++ b/plugin/.gradle/buildOutputCleanup/cache.properties
@@ -1,2 +1,0 @@
-#Sat Aug 02 22:27:46 UTC 2025
-gradle.version=8.11

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/commands/LeaveCommand.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/commands/LeaveCommand.kt
@@ -40,7 +40,7 @@ class LeaveCommand {
             .onFailure { err ->
                 when (err) {
                     MinigameLeaveError.PlayerNotInMinigame -> {
-                        return@onFailure
+                        sender.sendMessage(mm("<red>You are not in anything you can leave</red>"))
                     }
                     MinigameLeaveError.HubNotReady -> {
                         sender.sendMessage(
@@ -48,15 +48,14 @@ class LeaveCommand {
                                 "<red>Hub world is still loading, please try again in a moment</red>"
                             )
                         )
-                        return
+                    }
+                    MinigameLeaveError.Unknown -> {
+                        sender.sendMessage(mm("<red>An unknown error occurred which caused you to be unable to leave this minigame</red>"))
                     }
                     else -> {
                         sender.sendMessage(mm("<red>You cannot leave this minigame</red>"))
-                        return
                     }
                 }
             }
-
-        sender.sendMessage(mm("<red>You are not in anything you can leave</red>"))
     }
 }

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/kits/instances/KitInstance.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/kits/instances/KitInstance.kt
@@ -36,13 +36,13 @@ open class KitInstance(val definition: KitDefinition, val player: Player) {
 
         abilityInstances.forEach {
             it.teardown()
-            abilityInstances.remove(it)
         }
+        abilityInstances.clear()
 
         passiveInstances.forEach {
             it.teardown()
-            passiveInstances.remove(it)
         }
+        passiveInstances.clear()
 
         player.sendDebugMessage("The ${definition.name} kit has been removed")
     }

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/instances/MinigameInstance.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/instances/MinigameInstance.kt
@@ -74,9 +74,6 @@ abstract class MinigameInstance(val definition: MinigameDefinition, val teams: L
         // Remove the player from teams
         teams.forEach { team -> team.players.remove(player) }
 
-        // Unassign kit
-        KitService.unassignKit(player)
-
         // Check if minigame should end and clean up
         if (shouldEndMinigame()) {
             SuperSmashMobsBrawl.instance.launch { onMinigameEnd() }

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/instances/TestingMinigameInstance.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/instances/TestingMinigameInstance.kt
@@ -4,6 +4,7 @@ import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.onFailure
+import com.github.shynixn.mccoroutine.bukkit.minecraftDispatcher
 import dev.betrix.superSmashMobsBrawl.SuperSmashMobsBrawl
 import dev.betrix.superSmashMobsBrawl.minigames.definitions.MinigameDefinition
 import dev.betrix.superSmashMobsBrawl.models.MinigameTeam
@@ -14,6 +15,7 @@ import dev.betrix.superSmashMobsBrawl.services.WorldService
 import dev.betrix.superSmashMobsBrawl.utils.createLocation
 import gg.flyte.twilight.extension.feed
 import gg.flyte.twilight.extension.heal
+import kotlinx.coroutines.withContext
 import org.bukkit.World
 
 class TestingMinigameInstance(definition: MinigameDefinition, teams: List<MinigameTeam>) :
@@ -44,17 +46,22 @@ class TestingMinigameInstance(definition: MinigameDefinition, teams: List<Miniga
     }
 
     override suspend fun teardownMinigame() {
+        val playersToCleanup = teams.flatMap { it.players.toList() }
+        
         // Unassign kits from all players
-        players.forEach { player ->
-            HubService.teleportToDefaultHub(player)
-            KitService.unassignKit(player)
-        }
+        withContext(SuperSmashMobsBrawl.instance.minecraftDispatcher) {
+            playersToCleanup.forEach { player ->
+                HubService.teleportToDefaultHub(player)
+                KitService.unassignKit(player)
+            }
 
-        WorldService.deleteWorld(world)
-        MinigameService.removeMinigameInstance(this)
+            WorldService.deleteWorld(world)
+            MinigameService.removeMinigameInstance(this@TestingMinigameInstance)
+        }
     }
 
     override fun shouldEndMinigame(): Boolean {
-        return players.isEmpty()
+        // Create safe copy to avoid ConcurrentModificationException
+        return teams.flatMap { it.players }.isEmpty()
     }
 }

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/HubService.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/HubService.kt
@@ -1,5 +1,8 @@
 package dev.betrix.superSmashMobsBrawl.services
 
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.mapBoth
 import com.github.shynixn.mccoroutine.bukkit.launch
 import dev.betrix.superSmashMobsBrawl.maps.SsmbMap
@@ -111,40 +114,43 @@ object HubService {
     }
 
     /** Teleport a player to a specific hub */
-    fun teleportToHub(player: Player, loadedWorld: LoadedWorld) {
-        if (loadedWorld.mapDefinition.spawnPoints.isNotEmpty()) {
-            val spawnPoint = loadedWorld.mapDefinition.spawnPoints[0]
-            player.teleport(createLocation(loadedWorld.world, spawnPoint))
-            player.inventory.clear()
-            player.feed()
-            player.heal()
-            player.resetWalkSpeed()
-            player.resetFlySpeed()
-            player.gameMode = GameMode.SURVIVAL
-            player.fallDistance = 0f
-            playersInHub.add(player)
+    fun teleportToHub(player: Player, loadedWorld: LoadedWorld): Result<Unit, Exception> {
+        if (loadedWorld.mapDefinition.spawnPoints.isEmpty()) {
+            return Err(RuntimeException("Hub spawn points were empty"))
         }
+
+        val spawnPoint = loadedWorld.mapDefinition.spawnPoints[0]
+        player.teleport(createLocation(loadedWorld.world, spawnPoint))
+        player.inventory.clear()
+        player.feed()
+        player.heal()
+        player.resetWalkSpeed()
+        player.resetFlySpeed()
+        player.gameMode = GameMode.SURVIVAL
+        player.fallDistance = 0f
+        playersInHub.add(player)
+
+        return Ok(Unit)
     }
 
     /** Teleport a player to the default hub */
-    fun teleportToDefaultHub(player: Player) {
+    fun teleportToDefaultHub(player: Player): Result<Unit, Exception> {
         if (!::defaultLoadedHubWorld.isInitialized) {
             throw IllegalStateException("Default hub world is not yet initialized")
         }
-        teleportToHub(player, defaultLoadedHubWorld)
+        return teleportToHub(player, defaultLoadedHubWorld)
     }
 
     /** Teleport a player to the default hub with result handling */
-    fun tryTeleportToDefaultHub(player: Player): Result<Unit> {
+    fun tryTeleportToDefaultHub(player: Player): Result<Unit, Exception> {
         return if (::defaultLoadedHubWorld.isInitialized) {
             try {
                 teleportToHub(player, defaultLoadedHubWorld)
-                Result.success(Unit)
             } catch (e: Exception) {
-                Result.failure(e)
+                Err(e)
             }
         } else {
-            Result.failure(IllegalStateException("Default hub world is not yet initialized"))
+            Err(IllegalStateException("Default hub world is not yet initialized"))
         }
     }
 

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/HubService.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/HubService.kt
@@ -136,7 +136,7 @@ object HubService {
     /** Teleport a player to the default hub */
     fun teleportToDefaultHub(player: Player): Result<Unit, Exception> {
         if (!::defaultLoadedHubWorld.isInitialized) {
-            throw IllegalStateException("Default hub world is not yet initialized")
+            return Err(IllegalStateException("Default hub world is not yet initialized"))
         }
         return teleportToHub(player, defaultLoadedHubWorld)
     }

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/KitService.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/KitService.kt
@@ -8,7 +8,6 @@ import dev.betrix.superSmashMobsBrawl.SuperSmashMobsBrawl
 import dev.betrix.superSmashMobsBrawl.kits.definitions.CreeperKitDefinition
 import dev.betrix.superSmashMobsBrawl.kits.definitions.KitDefinition
 import dev.betrix.superSmashMobsBrawl.kits.instances.KitInstance
-import kotlinx.coroutines.launch
 import org.bukkit.entity.Player
 import java.util.concurrent.ConcurrentHashMap
 
@@ -84,7 +83,7 @@ object KitService {
                 try {
                     kitInstance.teardown()
                 } catch (e: Exception) {
-                    plugin.logger.warning("Error during kit teardown: ${e.message}")
+                    plugin.logger.warning("Error during kit teardown for player ${player.name}: ${e.message}")
                 }
             }
         }

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/KitService.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/KitService.kt
@@ -3,18 +3,24 @@ package dev.betrix.superSmashMobsBrawl.services
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
+import com.github.shynixn.mccoroutine.bukkit.launch
+import dev.betrix.superSmashMobsBrawl.SuperSmashMobsBrawl
 import dev.betrix.superSmashMobsBrawl.kits.definitions.CreeperKitDefinition
 import dev.betrix.superSmashMobsBrawl.kits.definitions.KitDefinition
 import dev.betrix.superSmashMobsBrawl.kits.instances.KitInstance
+import kotlinx.coroutines.launch
 import org.bukkit.entity.Player
+import java.util.concurrent.ConcurrentHashMap
 
 enum class AssignKitError {
     PLAYER_HAS_KIT
 }
 
 object KitService {
-    private val playerSelectedKits = hashMapOf<Player, KitDefinition>()
-    private val assignedKits = hashMapOf<Player, KitInstance>()
+    private val playerSelectedKits = ConcurrentHashMap<Player, KitDefinition>()
+    private val assignedKits = ConcurrentHashMap<Player, KitInstance>()
+
+    private val plugin = SuperSmashMobsBrawl.instance
 
     fun playerSelectKit(player: Player, kitDefinition: KitDefinition) {
         playerSelectedKits[player] = kitDefinition
@@ -46,20 +52,42 @@ object KitService {
     }
 
     fun unassignKit(player: Player): KitInstance? {
+        // Remove the kit instance immediately to prevent concurrent access
         val kitInstance = assignedKits.remove(player)
-        kitInstance?.teardown()
+
+        // Run teardown asynchronously to prevent concurrent modification
+        kitInstance?.let { instance ->
+            // Assuming you have access to your plugin's coroutine scope
+            // You might need to adjust this based on your mccoroutine setup
+            plugin.launch {
+                try {
+                    instance.teardown()
+                } catch (e: Exception) {
+                    // Handle any exceptions during teardown
+                    plugin.logger.warning("Error during kit teardown for player ${player.name}: ${e.message}")
+                }
+            }
+        }
+
         return kitInstance
     }
 
     fun unassignKit(kitInstance: KitInstance) {
-        val entry = assignedKits.filterValues { it == kitInstance }.keys.firstOrNull()
+        // Thread-safe way to find and remove the kit instance
+        val playerToRemove = assignedKits.entries.find { it.value == kitInstance }?.key
 
-        if (entry == null) {
-            return
+        playerToRemove?.let { player ->
+            assignedKits.remove(player)
+
+            // Run teardown asynchronously
+            plugin.launch {
+                try {
+                    kitInstance.teardown()
+                } catch (e: Exception) {
+                    plugin.logger.warning("Error during kit teardown: ${e.message}")
+                }
+            }
         }
-
-        assignedKits.remove(entry)
-        kitInstance.teardown()
     }
 
     fun getKitInstance(player: Player): KitInstance? {

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/MinigameService.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/MinigameService.kt
@@ -73,10 +73,11 @@ object MinigameService {
                 .onPlayerLeave(player)
                 .onSuccess {
                     // Try to move player back to hub
-                    val hubResult = HubService.tryTeleportToDefaultHub(player)
-                    if (hubResult.isFailure) {
-                        return Err(MinigameLeaveError.HubNotReady)
-                    }
+                    HubService.tryTeleportToDefaultHub(player)
+                        .onFailure {
+                            // Log the teleportation failure but don't fail the leave operation
+                            SuperSmashMobsBrawl.instance.logger.warning("Failed to teleport ${player.name} to hub: ${it.message}")
+                        }
                 }
                 .onFailure {
                     return Err(MinigameLeaveError.NotAllowedToLeave)

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/MinigameService.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/MinigameService.kt
@@ -74,6 +74,7 @@ object MinigameService {
                 .onPlayerLeave(player)
                 .onSuccess {
                     KitService.unassignKit(player)
+
                     // Try to move player back to hub
                     HubService.tryTeleportToDefaultHub(player)
                         .onFailure {

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/MinigameService.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/MinigameService.kt
@@ -10,6 +10,7 @@ import dev.betrix.superSmashMobsBrawl.SuperSmashMobsBrawl
 import dev.betrix.superSmashMobsBrawl.minigames.definitions.MinigameDefinition
 import dev.betrix.superSmashMobsBrawl.minigames.instances.MinigameInstance
 import dev.betrix.superSmashMobsBrawl.models.MinigameTeam
+import dev.betrix.superSmashMobsBrawl.utils.mm
 import org.bukkit.entity.Player
 
 sealed class MinigameInitError {
@@ -72,11 +73,13 @@ object MinigameService {
             minigameInstance
                 .onPlayerLeave(player)
                 .onSuccess {
+                    KitService.unassignKit(player)
                     // Try to move player back to hub
                     HubService.tryTeleportToDefaultHub(player)
                         .onFailure {
                             // Log the teleportation failure but don't fail the leave operation
-                            SuperSmashMobsBrawl.instance.logger.warning("Failed to teleport ${player.name} to hub: ${it.message}")
+                            player.kick(mm("<red>We couldn't put you back in the hub</red>"))
+                            SuperSmashMobsBrawl.instance.logger.severe("Failed to teleport ${player.name} to hub: ${it.message}")
                         }
                 }
                 .onFailure {
@@ -85,6 +88,7 @@ object MinigameService {
 
             return Ok(Unit)
         } catch (e: Exception) {
+            e.printStackTrace()
             Err(MinigameLeaveError.Unknown)
         }
     }


### PR DESCRIPTION
Fix the leave command to always teleport players to the hub and ensure minigame exit even if teleportation fails.

Previously, a failed hub teleportation would prevent the player from fully leaving the minigame. This PR modifies `MinigameService.handlePlayerLeave` to log a warning on teleportation failure instead of blocking the entire leave operation, ensuring players are always removed from the minigame and their kit is unassigned. The `shouldEndMinigame` method was already correctly invoked by `onPlayerLeave`.

---
<a href="https://cursor.com/background-agent?bcId=bc-d89e5738-2807-4019-91d3-ab9c4c28d57a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d89e5738-2807-4019-91d3-ab9c4c28d57a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved feedback messages when players attempt to leave a minigame, including specific messages for various error cases.
  * Enhanced stability and safety when tearing down kits and handling player removal to prevent runtime errors and concurrent modification issues.

* **Refactor**
  * Updated several internal services to use thread-safe data structures and asynchronous operations for better performance and reliability.
  * Improved error handling and messaging during player teleportation and kit unassignment.

* **New Features**
  * Introduced more explicit and user-friendly error messages for unknown issues during minigame leave attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->