### PR TITLE
Implement minigame passive and ability blacklisting

### DIFF
--- a/BLACKLIST_SYSTEM.md
+++ b/BLACKLIST_SYSTEM.md
@@ -1,0 +1,147 @@
+# Minigame Blacklist System
+
+This document explains the passive and ability blacklist system for minigame definitions.
+
+## Overview
+
+The blacklist system allows minigame definitions to specify which passives and abilities should be disabled for all kits within that minigame. This provides fine-grained control over gameplay mechanics for different minigame types.
+
+## Implementation
+
+### MinigameDefinition Changes
+
+The `MinigameDefinition` abstract class now includes two new properties:
+
+```kotlin
+/**
+ * List of passive definitions that are blacklisted in this minigame.
+ * These passives will not be enabled for any kit in this minigame.
+ */
+open val blacklistedPassives: List<PassiveDefinition> = emptyList()
+
+/**
+ * List of ability definitions that are blacklisted in this minigame.
+ * These abilities will not be enabled for any kit in this minigame.
+ */
+open val blacklistedAbilities: List<AbilityDefinition> = emptyList()
+```
+
+### TestingMinigameDefinition Example
+
+The `TestingMinigameDefinition` demonstrates how to use the blacklist system:
+
+```kotlin
+object TestingMinigameDefinition : MinigameDefinition() {
+    override val name = "Testing"
+    override val id = "testing"
+
+    override val metadata = minigame {
+        description = "A simple testing minigame"
+        isHidden = true
+        playersPerTeam = 1
+        amountOfTeams = 1
+        allowKitSwitching = true
+
+        whitelistMap("campsite")
+    }
+
+    override val blacklistedPassives = listOf(
+        RegenerationPassiveDefinition,
+        HungerPassiveDefinition
+    )
+
+    override fun createInstance(teams: List<MinigameTeam>): MinigameInstance {
+        return TestingMinigameInstance(this, teams)
+    }
+}
+```
+
+### KitInstance Filtering
+
+The `KitInstance.setup()` method now filters out blacklisted passives and abilities:
+
+```kotlin
+open fun setup() {
+    // Filter out blacklisted abilities
+    val allowedAbilities = definition.metadata.abilities.filter { ability ->
+        minigameDefinition?.blacklistedAbilities?.contains(ability) != true
+    }
+
+    allowedAbilities.forEach {
+        val abilityInstance = it.createInstance(player)
+        abilityInstances.add(abilityInstance)
+        abilityInstance.setup()
+    }
+
+    // Filter out blacklisted passives
+    val allowedPassives = definition.metadata.passives.filter { passive ->
+        minigameDefinition?.blacklistedPassives?.contains(passive) != true
+    }
+
+    allowedPassives.forEach {
+        val passiveInstance = it.createInstance(player)
+        passiveInstances.add(passiveInstance)
+        passiveInstance.setup()
+    }
+
+    // Setup hotbar items for abilities
+    HotbarService.setupHotbarItems(this)
+
+    player.sendDebugMessage("You have been given the ${definition.name} kit")
+}
+```
+
+### KitService Integration
+
+The `KitService` now supports passing minigame context when assigning kits:
+
+```kotlin
+fun assignKit(
+    player: Player,
+    minigameDefinition: MinigameDefinition,
+): Result<KitInstance, AssignKitError>
+```
+
+This ensures that when kits are assigned within a minigame, the blacklist filtering is applied.
+
+## Usage
+
+### Adding Blacklisted Items to a Minigame
+
+To blacklist passives or abilities in a minigame:
+
+1. Override the `blacklistedPassives` and/or `blacklistedAbilities` properties in your minigame definition
+2. Add the passive/ability definitions to the list
+3. The filtering will automatically apply when kits are assigned within that minigame
+
+### Example: Blacklisting Multiple Items
+
+```kotlin
+object MyCustomMinigameDefinition : MinigameDefinition() {
+    // ... other properties ...
+
+    override val blacklistedPassives = listOf(
+        RegenerationPassiveDefinition,
+        HungerPassiveDefinition,
+        SomeOtherPassiveDefinition
+    )
+
+    override val blacklistedAbilities = listOf(
+        ExplosionAbilityDefinition,
+        SomeOtherAbilityDefinition
+    )
+}
+```
+
+## Benefits
+
+1. **Gameplay Balance**: Disable overpowered or inappropriate mechanics for specific minigame types
+2. **Customization**: Each minigame can have its own set of rules and restrictions
+3. **Flexibility**: Easy to add or remove blacklisted items without changing kit definitions
+4. **Maintainability**: Centralized control over what's allowed in each minigame
+
+## Current Implementation
+
+- **TestingMinigame**: Blacklists `RegenerationPassiveDefinition` and `HungerPassiveDefinition`
+- **Other Minigames**: Can be configured with their own blacklists as needed
+- **Hub/Outside Minigames**: No blacklist filtering applied (full kit functionality)

--- a/plugin/.gradle/buildOutputCleanup/cache.properties
+++ b/plugin/.gradle/buildOutputCleanup/cache.properties
@@ -1,2 +1,2 @@
-#Sat Aug 02 02:53:19 UTC 2025
+#Sat Aug 02 22:29:59 UTC 2025
 gradle.version=8.11

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/SuperSmashMobsBrawl.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/SuperSmashMobsBrawl.kt
@@ -6,7 +6,9 @@ import dev.betrix.superSmashMobsBrawl.commands.KitCommand
 import dev.betrix.superSmashMobsBrawl.commands.LeaveCommand
 import dev.betrix.superSmashMobsBrawl.commands.QueueCommand
 import dev.betrix.superSmashMobsBrawl.commands.argumentResolvers.MinigameDefinitionArgument
+import dev.betrix.superSmashMobsBrawl.extensions.hasPassive
 import dev.betrix.superSmashMobsBrawl.minigames.definitions.MinigameDefinition
+import dev.betrix.superSmashMobsBrawl.passives.definitions.HungerPassiveDefinition
 import dev.betrix.superSmashMobsBrawl.services.DebugService
 import dev.betrix.superSmashMobsBrawl.services.HotbarService
 import dev.betrix.superSmashMobsBrawl.services.HubProtectionService
@@ -17,10 +19,13 @@ import dev.rollczi.litecommands.LiteCommands
 import dev.rollczi.litecommands.bukkit.LiteBukkitFactory
 import gg.flyte.twilight.Twilight
 import gg.flyte.twilight.event.event
+import gg.flyte.twilight.extension.feed
 import gg.flyte.twilight.twilight
 import org.bukkit.GameMode
 import org.bukkit.command.CommandSender
+import org.bukkit.entity.Player
 import org.bukkit.event.entity.EntityPickupItemEvent
+import org.bukkit.event.entity.FoodLevelChangeEvent
 import org.bukkit.event.inventory.InventoryMoveItemEvent
 import org.bukkit.event.player.PlayerDropItemEvent
 
@@ -65,6 +70,16 @@ class SuperSmashMobsBrawl : SuspendingJavaPlugin() {
             }
 
             isCancelled = true
+        }
+
+        event<FoodLevelChangeEvent> {
+            if (entity is Player) {
+                val player = entity as Player
+                if (!player.hasPassive(HungerPassiveDefinition)) {
+                    player.feed()
+                    isCancelled = true
+                }
+            }
         }
 
         event<EntityPickupItemEvent> { isCancelled = true }

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/extensions/player.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/extensions/player.kt
@@ -1,8 +1,12 @@
 package dev.betrix.superSmashMobsBrawl.extensions
 
+import dev.betrix.superSmashMobsBrawl.passives.definitions.PassiveDefinition
 import dev.betrix.superSmashMobsBrawl.services.DebugService
+import dev.betrix.superSmashMobsBrawl.services.KitService
+import dev.betrix.superSmashMobsBrawl.services.MinigameService
 import dev.betrix.superSmashMobsBrawl.utils.mm
 import org.bukkit.entity.Player
+import org.checkerframework.checker.units.qual.min
 
 /**
  * Check if debug mode is enabled for this player.
@@ -24,4 +28,10 @@ fun Player.sendDebugMessage(message: String) {
     }
 
     sendMessage(mm("<gray>[DEBUG] $message</gray>"))
+}
+
+fun Player.hasPassive(definition: PassiveDefinition): Boolean {
+    val kit = KitService.getKitInstance(this)
+
+    return kit?.passiveInstances?.find { it.definition.id == definition.id } != null
 }

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/kits/definitions/CreeperKitDefinition.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/kits/definitions/CreeperKitDefinition.kt
@@ -4,6 +4,7 @@ import dev.betrix.superSmashMobsBrawl.abilities.definitions.ExplosionAbilityDefi
 import dev.betrix.superSmashMobsBrawl.abilities.definitions.SulphurBombAbilityDefinition
 import dev.betrix.superSmashMobsBrawl.kits.instances.CreeperKitInstance
 import dev.betrix.superSmashMobsBrawl.kits.kit
+import dev.betrix.superSmashMobsBrawl.minigames.definitions.MinigameDefinition
 import dev.betrix.superSmashMobsBrawl.passives.definitions.DoubleJumpPassiveDefinition
 import dev.betrix.superSmashMobsBrawl.passives.definitions.HungerPassiveDefinition
 import dev.betrix.superSmashMobsBrawl.passives.definitions.RegenerationPassiveDefinition
@@ -25,7 +26,7 @@ object CreeperKitDefinition : KitDefinition() {
         ability(ExplosionAbilityDefinition)
     }
 
-    override fun createInstance(player: Player): CreeperKitInstance {
-        return CreeperKitInstance(this, player)
+    override fun createInstance(player: Player, minigameDefinition: MinigameDefinition?): CreeperKitInstance {
+        return CreeperKitInstance(this, player, minigameDefinition)
     }
 }

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/kits/definitions/KitDefinition.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/kits/definitions/KitDefinition.kt
@@ -2,6 +2,7 @@ package dev.betrix.superSmashMobsBrawl.kits.definitions
 
 import dev.betrix.superSmashMobsBrawl.kits.KitMetadata
 import dev.betrix.superSmashMobsBrawl.kits.instances.KitInstance
+import dev.betrix.superSmashMobsBrawl.minigames.definitions.MinigameDefinition
 import org.bukkit.entity.Player
 
 abstract class KitDefinition {
@@ -9,5 +10,5 @@ abstract class KitDefinition {
     abstract val id: String
     abstract val metadata: KitMetadata
 
-    abstract fun createInstance(player: Player): KitInstance
+    abstract fun createInstance(player: Player, minigameDefinition: MinigameDefinition? = null): KitInstance
 }

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/kits/instances/CreeperKitInstance.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/kits/instances/CreeperKitInstance.kt
@@ -1,7 +1,11 @@
 package dev.betrix.superSmashMobsBrawl.kits.instances
 
 import dev.betrix.superSmashMobsBrawl.kits.definitions.KitDefinition
+import dev.betrix.superSmashMobsBrawl.minigames.definitions.MinigameDefinition
 import org.bukkit.entity.Player
 
-class CreeperKitInstance(definition: KitDefinition, player: Player) :
-    KitInstance(definition, player) {}
+class CreeperKitInstance(
+    definition: KitDefinition, 
+    player: Player,
+    minigameDefinition: MinigameDefinition? = null
+) : KitInstance(definition, player, minigameDefinition) {}

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/kits/instances/KitInstance.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/kits/instances/KitInstance.kt
@@ -19,7 +19,15 @@ open class KitInstance(
     open fun setup() {
         // Filter out blacklisted abilities
         val allowedAbilities = definition.metadata.abilities.filter { ability ->
-            minigameDefinition?.blacklistedAbilities?.contains(ability) != true
+            when(minigameDefinition?.blacklistedAbilities?.contains(ability) == true) {
+                true -> {
+                    player.sendDebugMessage("[Kit] Ability <light_purple>${ability.name}</light_purple> was blacklisted from this minigame")
+                    false
+                }
+                false -> {
+                    true
+                }
+            }
         }
 
         allowedAbilities.forEach {
@@ -30,7 +38,15 @@ open class KitInstance(
 
         // Filter out blacklisted passives
         val allowedPassives = definition.metadata.passives.filter { passive ->
-            minigameDefinition?.blacklistedPassives?.contains(passive) != true
+            when(minigameDefinition?.blacklistedPassives?.contains(passive) == true) {
+                true -> {
+                    player.sendDebugMessage("[Kit] Passive <light_purple>${passive.name}</light_purple> was blacklisted from this minigame")
+                    false
+                }
+                false -> {
+                    true
+                }
+            }
         }
 
         allowedPassives.forEach {

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/kits/instances/KitInstance.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/kits/instances/KitInstance.kt
@@ -3,22 +3,37 @@ package dev.betrix.superSmashMobsBrawl.kits.instances
 import dev.betrix.superSmashMobsBrawl.abilities.instances.AbilityInstance
 import dev.betrix.superSmashMobsBrawl.extensions.sendDebugMessage
 import dev.betrix.superSmashMobsBrawl.kits.definitions.KitDefinition
+import dev.betrix.superSmashMobsBrawl.minigames.definitions.MinigameDefinition
 import dev.betrix.superSmashMobsBrawl.passives.instances.PassiveInstance
 import dev.betrix.superSmashMobsBrawl.services.HotbarService
 import org.bukkit.entity.Player
 
-open class KitInstance(val definition: KitDefinition, val player: Player) {
+open class KitInstance(
+    val definition: KitDefinition, 
+    val player: Player,
+    private val minigameDefinition: MinigameDefinition? = null
+) {
     val abilityInstances = arrayListOf<AbilityInstance>()
     val passiveInstances = arrayListOf<PassiveInstance>()
 
     open fun setup() {
-        definition.metadata.abilities.forEach {
+        // Filter out blacklisted abilities
+        val allowedAbilities = definition.metadata.abilities.filter { ability ->
+            minigameDefinition?.blacklistedAbilities?.contains(ability) != true
+        }
+
+        allowedAbilities.forEach {
             val abilityInstance = it.createInstance(player)
             abilityInstances.add(abilityInstance)
             abilityInstance.setup()
         }
 
-        definition.metadata.passives.forEach {
+        // Filter out blacklisted passives
+        val allowedPassives = definition.metadata.passives.filter { passive ->
+            minigameDefinition?.blacklistedPassives?.contains(passive) != true
+        }
+
+        allowedPassives.forEach {
             val passiveInstance = it.createInstance(player)
             passiveInstances.add(passiveInstance)
             passiveInstance.setup()

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/definitions/MinigameDefinition.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/definitions/MinigameDefinition.kt
@@ -1,13 +1,27 @@
 package dev.betrix.superSmashMobsBrawl.minigames.definitions
 
+import dev.betrix.superSmashMobsBrawl.abilities.definitions.AbilityDefinition
 import dev.betrix.superSmashMobsBrawl.minigames.MinigameMetadata
 import dev.betrix.superSmashMobsBrawl.minigames.instances.MinigameInstance
 import dev.betrix.superSmashMobsBrawl.models.MinigameTeam
+import dev.betrix.superSmashMobsBrawl.passives.definitions.PassiveDefinition
 
 abstract class MinigameDefinition {
     abstract val name: String
     abstract val id: String
     abstract val metadata: MinigameMetadata
+
+    /**
+     * List of passive definitions that are blacklisted in this minigame.
+     * These passives will not be enabled for any kit in this minigame.
+     */
+    open val blacklistedPassives: List<PassiveDefinition> = emptyList()
+
+    /**
+     * List of ability definitions that are blacklisted in this minigame.
+     * These abilities will not be enabled for any kit in this minigame.
+     */
+    open val blacklistedAbilities: List<AbilityDefinition> = emptyList()
 
     abstract fun createInstance(teams: List<MinigameTeam>): MinigameInstance
 }

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/definitions/TestingMinigameDefinition.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/definitions/TestingMinigameDefinition.kt
@@ -4,6 +4,8 @@ import dev.betrix.superSmashMobsBrawl.minigames.instances.MinigameInstance
 import dev.betrix.superSmashMobsBrawl.minigames.instances.TestingMinigameInstance
 import dev.betrix.superSmashMobsBrawl.minigames.minigame
 import dev.betrix.superSmashMobsBrawl.models.MinigameTeam
+import dev.betrix.superSmashMobsBrawl.passives.definitions.HungerPassiveDefinition
+import dev.betrix.superSmashMobsBrawl.passives.definitions.RegenerationPassiveDefinition
 
 object TestingMinigameDefinition : MinigameDefinition() {
     override val name = "Testing"
@@ -18,6 +20,11 @@ object TestingMinigameDefinition : MinigameDefinition() {
 
         whitelistMap("campsite")
     }
+
+    override val blacklistedPassives = listOf(
+        RegenerationPassiveDefinition,
+        HungerPassiveDefinition
+    )
 
     override fun createInstance(teams: List<MinigameTeam>): MinigameInstance {
         return TestingMinigameInstance(this, teams)

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/instances/TestingMinigameInstance.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/instances/TestingMinigameInstance.kt
@@ -31,7 +31,7 @@ class TestingMinigameInstance(definition: MinigameDefinition, teams: List<Miniga
                 player.heal()
                 player.teleport(createLocation(world, map.spawnPoints[0]))
 
-                KitService.assignKit(player).onFailure { error ->
+                KitService.assignKit(player, definition).onFailure { error ->
                     // Log error if kit assignment fails
                     SuperSmashMobsBrawl.instance.logger.warning(
                         "Failed to assign kit to ${player.name}: $error"

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/instances/TwoPlayerDuelsMinigameInstance.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/instances/TwoPlayerDuelsMinigameInstance.kt
@@ -70,7 +70,7 @@ class TwoPlayerDuelsMinigameInstance(definition: MinigameDefinition, teams: List
                 val playerNumber = teamIdx * definition.metadata.playersPerTeam + playerIdx
                 player.teleport(createLocation(world, spawnPoints[playerNumber]))
 
-                KitService.assignKit(player).onFailure {
+                KitService.assignKit(player, definition).onFailure {
                     when (it) {
                         AssignKitError.PLAYER_HAS_KIT ->
                             return Err(
@@ -302,14 +302,14 @@ class TwoPlayerDuelsMinigameInstance(definition: MinigameDefinition, teams: List
         deadPlayers.remove(player)
 
         // Reassign kit
-        KitService.assignKit(player).onFailure {
+        KitService.assignKit(player, definition).onFailure {
             when (it) {
                 AssignKitError.PLAYER_HAS_KIT -> {
                     plugin.logger.warning(
                         "Player ${player.name} already had a kit during respawn, reassigning..."
                     )
                     KitService.unassignKit(player)
-                    KitService.assignKit(player).onFailure { error ->
+                    KitService.assignKit(player, definition).onFailure { error ->
                         plugin.logger.severe(
                             "Failed to reassign kit to ${player.name} during respawn: $error"
                         )

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/HubProtectionService.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/HubProtectionService.kt
@@ -2,7 +2,6 @@ package dev.betrix.superSmashMobsBrawl.services
 
 import dev.betrix.superSmashMobsBrawl.extensions.isHubInteractable
 import gg.flyte.twilight.event.event
-import gg.flyte.twilight.extension.feed
 import org.bukkit.GameMode
 import org.bukkit.entity.Player
 import org.bukkit.event.block.BlockBreakEvent
@@ -11,7 +10,6 @@ import org.bukkit.event.entity.EntityDamageByEntityEvent
 import org.bukkit.event.entity.EntityDamageEvent
 import org.bukkit.event.entity.EntityPickupItemEvent
 import org.bukkit.event.entity.EntityTargetEvent
-import org.bukkit.event.entity.FoodLevelChangeEvent
 import org.bukkit.event.player.PlayerInteractEntityEvent
 import org.bukkit.event.player.PlayerInteractEvent
 import org.bukkit.event.weather.WeatherChangeEvent
@@ -95,17 +93,6 @@ object HubProtectionService {
             if (entity is Player) {
                 val player = entity as Player
                 if (HubService.isPlayerInHub(player)) {
-                    isCancelled = true
-                }
-            }
-        }
-
-        // Food level protection
-        event<FoodLevelChangeEvent> {
-            if (entity is Player) {
-                val player = entity as Player
-                if (HubService.isPlayerInHub(player)) {
-                    player.feed()
                     isCancelled = true
                 }
             }

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/KitService.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/KitService.kt
@@ -6,6 +6,7 @@ import com.github.michaelbull.result.Result
 import dev.betrix.superSmashMobsBrawl.kits.definitions.CreeperKitDefinition
 import dev.betrix.superSmashMobsBrawl.kits.definitions.KitDefinition
 import dev.betrix.superSmashMobsBrawl.kits.instances.KitInstance
+import dev.betrix.superSmashMobsBrawl.minigames.definitions.MinigameDefinition
 import org.bukkit.entity.Player
 
 enum class AssignKitError {
@@ -30,13 +31,32 @@ object KitService {
 
     fun assignKit(
         player: Player,
+        minigameDefinition: MinigameDefinition,
+    ): Result<KitInstance, AssignKitError> {
+        if (!playerSelectedKits.containsKey(player) || playerSelectedKits[player] == null) {
+            playerSelectedKits[player] = CreeperKitDefinition // Default kit for now
+        }
+
+        return assignKit(player, playerSelectedKits[player] ?: CreeperKitDefinition, minigameDefinition)
+    }
+
+    fun assignKit(
+        player: Player,
         kitDefinition: KitDefinition,
+    ): Result<KitInstance, AssignKitError> {
+        return assignKit(player, kitDefinition, null)
+    }
+
+    fun assignKit(
+        player: Player,
+        kitDefinition: KitDefinition,
+        minigameDefinition: MinigameDefinition?,
     ): Result<KitInstance, AssignKitError> {
         if (assignedKits.containsKey(player)) {
             return Err(AssignKitError.PLAYER_HAS_KIT)
         }
 
-        val kitInstance = kitDefinition.createInstance(player)
+        val kitInstance = kitDefinition.createInstance(player, minigameDefinition)
         assignedKits[player] = kitInstance
 
         // Set up the kit (which will also set up hotbar items)


### PR DESCRIPTION
Add a passive and ability blacklist to minigame definitions to disable specific kit components per minigame.

---
<a href="https://cursor.com/background-agent?bcId=bc-a6a81330-8482-4d58-bf56-507fa84a0945">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a6a81330-8482-4d58-bf56-507fa84a0945">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a blacklist system for minigames to disable specific passives and abilities across all kits.
  * Minigame definitions can specify blacklisted passives and abilities.
  * Kits assigned within minigames automatically filter out blacklisted passives and abilities.
  * Added a new player extension to check for specific passives.
  * Added event handling to prevent hunger depletion for players without the hunger passive.

* **Bug Fixes**
  * Ensured kit assignment respects minigame-specific blacklists to maintain gameplay balance.

* **Documentation**
  * Added usage instructions and examples for the blacklist system in minigame configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->