### PR TITLE
Add coal particle trail to sulphur bomb

### DIFF
--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/abilities/instances/SulphurBombAbilityInstance.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/abilities/instances/SulphurBombAbilityInstance.kt
@@ -91,6 +91,17 @@ class SulphurBombAbilityInstance(definition: AbilityDefinition, player: Player) 
                     return@repeatingTask
                 }
 
+                // Spawn black particle trail behind the projectile
+                player.world.spawnParticle(
+                    Particle.SMOKE,
+                    projectile.location,
+                    3,
+                    0.1,
+                    0.1,
+                    0.1,
+                    0.01
+                )
+
                 val nearbyEntities =
                     projectile
                         .getNearbyEntities(projectileCollisionSize)


### PR DESCRIPTION
Add a black particle trail behind the sulphur bomb's coal projectile.

This uses `Particle.SMOKE` to visually represent the projectile's path, improving its visibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-6000ed0a-f7b4-4690-9b6d-058ad4a5786e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6000ed0a-f7b4-4690-9b6d-058ad4a5786e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>