### PR TITLE
Handle player respawn and kit assignment

### DIFF
--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/instances/TestingMinigameInstance.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/instances/TestingMinigameInstance.kt
@@ -4,6 +4,7 @@ import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.onFailure
+import com.github.shynixn.mccoroutine.bukkit.launch
 import com.github.shynixn.mccoroutine.bukkit.minecraftDispatcher
 import dev.betrix.superSmashMobsBrawl.SuperSmashMobsBrawl
 import dev.betrix.superSmashMobsBrawl.minigames.definitions.MinigameDefinition
@@ -13,10 +14,13 @@ import dev.betrix.superSmashMobsBrawl.services.KitService
 import dev.betrix.superSmashMobsBrawl.services.MinigameService
 import dev.betrix.superSmashMobsBrawl.services.WorldService
 import dev.betrix.superSmashMobsBrawl.utils.createLocation
+import gg.flyte.twilight.event.event
 import gg.flyte.twilight.extension.feed
 import gg.flyte.twilight.extension.heal
 import kotlinx.coroutines.withContext
 import org.bukkit.World
+import org.bukkit.entity.Player
+import org.bukkit.event.entity.PlayerDeathEvent
 
 class TestingMinigameInstance(definition: MinigameDefinition, teams: List<MinigameTeam>) :
     MinigameInstance(definition, teams) {
@@ -42,6 +46,8 @@ class TestingMinigameInstance(definition: MinigameDefinition, teams: List<Miniga
             }
         }
 
+        setupEventListeners()
+
         return Ok(Unit)
     }
 
@@ -63,5 +69,63 @@ class TestingMinigameInstance(definition: MinigameDefinition, teams: List<Miniga
     override fun shouldEndMinigame(): Boolean {
         // Create safe copy to avoid ConcurrentModificationException
         return teams.flatMap { it.players }.isEmpty()
+    }
+
+    private fun setupEventListeners() {
+        // Listen for PlayerDeathEvent to handle instant respawn
+        listeners.add(
+            event<PlayerDeathEvent> {
+                val player = player
+                if (!isPlayerInMinigame(player)) return@event
+
+                // Cancel the default death behavior
+                isCancelled = true
+
+                handlePlayerDeath(player)
+            }
+        )
+    }
+
+    private fun handlePlayerDeath(player: Player) {
+        // Check if player is still in the minigame
+        if (!isPlayerInMinigame(player)) {
+            return
+        }
+
+        // Unassign kit on death
+        KitService.unassignKit(player)
+
+        // Respawn player immediately at a random spawn point
+        SuperSmashMobsBrawl.instance.launch {
+            // Double-check that player is still in the minigame before respawning
+            if (!isPlayerInMinigame(player)) {
+                return@launch
+            }
+
+            val spawnPoints = map.spawnPoints
+            if (spawnPoints.isEmpty()) {
+                SuperSmashMobsBrawl.instance.logger.warning(
+                    "No spawn points available for ${player.name} in testing minigame"
+                )
+                return@launch
+            }
+
+            val randomSpawnPoint = spawnPoints.random()
+            val respawnLocation = createLocation(world, randomSpawnPoint)
+
+            // Teleport player to spawn point
+            player.teleport(respawnLocation)
+
+            // Heal and feed the player
+            player.heal()
+            player.feed()
+
+            // Reassign kit
+            KitService.assignKit(player, definition).onFailure { error ->
+                SuperSmashMobsBrawl.instance.logger.warning(
+                    "Failed to reassign kit to ${player.name} after respawn: ${error.name}"
+                )
+            }
+        }
     }
 }


### PR DESCRIPTION
Implement instant respawn for players in the testing minigame, including kit unassignment on death and re-assignment on respawn.

---
<a href="https://cursor.com/background-agent?bcId=bc-05d0b897-c18d-4ffc-a033-840eca3fc0e7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-05d0b897-c18d-4ffc-a033-840eca3fc0e7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Players now instantly respawn at a random location after death during the minigame, bypassing the normal death process.
  * Upon respawn, players are fully healed, fed, and their kit is automatically reassigned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->