### PR TITLE
Update language syntax for placeholders

### DIFF
--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/LangService.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/LangService.kt
@@ -5,7 +5,11 @@ import java.nio.charset.StandardCharsets
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.format.TextColor
 import net.kyori.adventure.text.minimessage.MiniMessage
+import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver
+import org.bukkit.configuration.ConfigurationSection
 import org.bukkit.configuration.file.YamlConfiguration
 import org.bukkit.plugin.java.JavaPlugin
 import org.koin.core.component.KoinComponent
@@ -19,13 +23,19 @@ class LangService : KoinComponent {
 
     private val miniMessage: MiniMessage = MiniMessage.miniMessage()
 
-    // Matches {content} with no nested braces
-    private val placeholderPattern: Pattern = Pattern.compile("\\{([^{}]+)}")
+    // Matches {content} with no nested braces (variables)
+    private val variablePattern: Pattern = Pattern.compile("\\{([^{}]+)}")
+
+    // Matches ${content} with no nested braces (lang references)
+    private val langRefPattern: Pattern = Pattern.compile("\\$\\{([^{}]+)}")
+
+    // Built once from the current language file; contains style placeholders for palette entries
+    private val paletteResolver: TagResolver by lazy { buildPaletteResolver() }
 
     fun t(key: String, varsBuilder: VarsBuilder.() -> Unit = {}): Component {
         val vars = VarsBuilder().apply(varsBuilder).build()
         val resolved = resolveAndFormat(key, vars, visited = mutableSetOf())
-        return miniMessage.deserialize(resolved)
+        return miniMessage.deserialize(resolved, paletteResolver)
     }
 
     private fun resolveAndFormat(
@@ -43,10 +53,10 @@ class LangService : KoinComponent {
                     return "[$key]"
                 }
 
-        // First interpolate simple variables so nested placeholders inside lang: paths are resolved
+        // First interpolate simple variables so nested placeholders inside reference keys are resolved
         val withVarsFirst = interpolateVariables(raw, vars)
 
-        // Then expand lang references (which may now include previously nested variables)
+        // Then expand ${...} references (which may now include previously nested variables)
         val expandedRefs = expandLangReferences(withVarsFirst, vars, visited)
 
         // Finally, interpolate any remaining variables from referenced strings
@@ -61,25 +71,19 @@ class LangService : KoinComponent {
         vars: Map<String, Any?>,
         visited: MutableSet<String>,
     ): String {
-        val matcher = placeholderPattern.matcher(text)
+        val matcher = langRefPattern.matcher(text)
         val sb = StringBuffer()
 
         while (matcher.find()) {
             val token = matcher.group(1).trim()
 
-            if (token.startsWith("lang:")) {
-                // token like "lang:minigames.test.name" (any nested vars should already be
-                // interpolated)
-                val resolvedPath = token.removePrefix("lang:").trim()
+            // token like "minigames.test.name" (any nested vars should already be interpolated)
+            val resolvedPath = token
 
-                // Resolve that key recursively
-                val replacement = resolveAndFormat(resolvedPath, vars, visited)
+            // Resolve that key recursively
+            val replacement = resolveAndFormat(resolvedPath, vars, visited)
 
-                matcher.appendReplacement(sb, Matcher.quoteReplacement(replacement))
-            } else {
-                // Keep other placeholders (variables) for later interpolation
-                matcher.appendReplacement(sb, Matcher.quoteReplacement(matcher.group()))
-            }
+            matcher.appendReplacement(sb, Matcher.quoteReplacement(replacement))
         }
 
         matcher.appendTail(sb)
@@ -87,14 +91,14 @@ class LangService : KoinComponent {
     }
 
     private fun interpolateVariables(text: String, vars: Map<String, Any?>): String {
-        val matcher = placeholderPattern.matcher(text)
+        val matcher = variablePattern.matcher(text)
         val sb = StringBuffer()
 
         while (matcher.find()) {
             val token = matcher.group(1).trim()
 
-            if (token.startsWith("lang:")) {
-                // Leave lang references untouched in this phase
+            // If this is actually a ${...} reference, leave untouched for the reference phase
+            if (token.startsWith("$")) {
                 matcher.appendReplacement(sb, Matcher.quoteReplacement(matcher.group()))
                 continue
             }
@@ -106,6 +110,29 @@ class LangService : KoinComponent {
 
         matcher.appendTail(sb)
         return sb.toString()
+    }
+
+    private fun buildPaletteResolver(): TagResolver {
+        val section: ConfigurationSection? = enLang.getConfigurationSection("palette")
+            ?: enLang.defaults?.getConfigurationSection("palette")
+
+        if (section == null) return TagResolver.empty()
+
+        val builder = TagResolver.builder()
+        for (name in section.getKeys(false)) {
+            val value = section.getString(name)?.trim().orEmpty()
+            val color = parseTextColor(value) ?: continue
+            builder.resolver(Placeholder.styling(name, color))
+        }
+        return builder.build()
+    }
+
+    private fun parseTextColor(value: String): TextColor? {
+        if (value.isEmpty()) return null
+        return when {
+            value.startsWith("#") -> TextColor.fromHexString(value)
+            else -> TextColor.fromCSSHexString(value) // attempt parse common formats/names if supported
+        }
     }
 
     class VarsBuilder {

--- a/plugin/src/main/resources/data/lang/en.yml
+++ b/plugin/src/main/resources/data/lang/en.yml
@@ -19,17 +19,23 @@ minigames:
   two_player_duels:
     name: "1v1 Duels"
     descriptions: "A competitive 1v1game mode"
+palette:
+  accent: "#8bd5ff"
+  error: "#f2b8c6"
+  text: "#e8edff"
+  frame: "#585b70"
+  brand: "#cba6f7"
 prefix: "<#585b70>[<gradient:#cba6f7:#585b70>Brawl</gradient><#585b70>]<reset>"
 messages:
   commands:
     onlyPlayers: "<red>On players can execute this command</red>"
   queue:
     leave:
-      notInQueue: "{lang:prefix} <#f2b8c6>You are not currently in a queue<#e8edff>"
-      success: "{lang:prefix} <#e8edff>You have left the queue for <#8bd5ff>{lang:minigames.{minigameId}.name}"
+      notInQueue: "${prefix} <#f2b8c6>You are not currently in a queue<#e8edff>"
+      success: "${prefix} <#e8edff>You have left the queue for <#8bd5ff>${minigames.{minigameId}.name}"
     join:
-      success: "{lang:prefix} <#e8edff>You have joined the queue for <#8bd5ff>{lang:minigames.{minigameId}.name}"
-      alreadyInQueue: "{lang:prefix} <#f2b8c6>You are already in a queue<newline>leave that one before joining a new one<#e8edff>"
+      success: "${prefix} <#e8edff>You have joined the queue for <#8bd5ff>${minigames.{minigameId}.name}"
+      alreadyInQueue: "${prefix} <#f2b8c6>You are already in a queue<newline>leave that one before joining a new one<#e8edff>"
     status:
-      inQueue: "{lang:prefix} <#e8edff>You are currently in the queue for <#8bd5ff>{lang:minigames.{minigameId}.name}"
-      notInQueue: "{lang:messages.queue.leave.notInQueue}"
+      inQueue: "${prefix} <#e8edff>You are currently in the queue for <#8bd5ff>${minigames.{minigameId}.name}"
+      notInQueue: "${messages.queue.leave.notInQueue}"

--- a/plugin/src/test/kotlin/dev/betrix/superSmashMobsBrawl/services/LangServiceTest.kt
+++ b/plugin/src/test/kotlin/dev/betrix/superSmashMobsBrawl/services/LangServiceTest.kt
@@ -28,9 +28,9 @@ class LangServiceTest :
             yml.set("greeting", "<green>Hello, {name}!")
             yml.set("farewell", "<red>Bye, {name}!")
             yml.set("minigames.test.name", "Test Minigame")
-            yml.set("withRef", "Welcome to {lang:minigames.{minigameId}.name}, {name}!")
-            yml.set("cycle.a", "{lang:cycle.b}")
-            yml.set("cycle.b", "{lang:cycle.a}")
+            yml.set("withRef", "Welcome to ${'$'}{minigames.{minigameId}.name}, {name}!")
+            yml.set("cycle.a", "${'$'}{cycle.b}")
+            yml.set("cycle.b", "${'$'}{cycle.a}")
             yml.save(enPath.toFile())
 
             startKoin { modules(module { single { plugin as JavaPlugin } }) }


### PR DESCRIPTION
Update language service to use `${}` for language references and add MiniMessage color palette support.

---
<a href="https://cursor.com/background-agent?bcId=bc-6523a37e-562e-4125-be56-e69b1d2b8cb5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6523a37e-562e-4125-be56-e69b1d2b8cb5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

