### PR TITLE
Implement team stocks minigame logic

### DIFF
--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/commands/QueueCommand.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/commands/QueueCommand.kt
@@ -76,8 +76,7 @@ class QueueCommand : KoinComponent {
             return
         }
 
-        QueueService
-            .removePlayer(sender)
+        QueueService.removePlayer(sender)
             .mapBoth(
                 success = {
                     lang.t("messages.queue.leave.success") { "minigameId" to it.minigame.id }

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/commands/QueueCommand.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/commands/QueueCommand.kt
@@ -4,6 +4,7 @@ import com.github.michaelbull.result.mapBoth
 import dev.betrix.superSmashMobsBrawl.extensions.hasDebugEnabled
 import dev.betrix.superSmashMobsBrawl.models.brawlData.MinigameDef
 import dev.betrix.superSmashMobsBrawl.services.LangService
+import dev.betrix.superSmashMobsBrawl.services.MinigameService
 import dev.betrix.superSmashMobsBrawl.services.QueueService
 import dev.betrix.superSmashMobsBrawl.utils.mm
 import dev.rollczi.litecommands.annotations.argument.Arg
@@ -19,6 +20,7 @@ import org.koin.core.component.inject
 class QueueCommand : KoinComponent {
 
     private val lang: LangService by inject()
+    private val minigameService: MinigameService by inject()
 
     @Execute
     fun queue(@Context sender: CommandSender) {
@@ -74,15 +76,26 @@ class QueueCommand : KoinComponent {
             return
         }
 
-        val playerMessage =
-            QueueService.removePlayer(sender)
-                .mapBoth(
-                    success = {
-                        lang.t("messages.queue.leave.success") { "minigameId" to it.minigame.id }
-                    },
-                    failure = { lang.t("messages.queue.leave.notInQueue") },
-                )
-
-        sender.sendMessage(playerMessage)
+        QueueService
+            .removePlayer(sender)
+            .mapBoth(
+                success = {
+                    lang.t("messages.queue.leave.success") { "minigameId" to it.minigame.id }
+                },
+                failure = {
+                    // If not in queue, fall back to leaving a running minigame
+                    minigameService
+                        .handlePlayerLeave(sender)
+                        .mapBoth(
+                            success = {
+                                lang.t("messages.minigames.leave.success") {
+                                    "minigameId" to it.minigameId
+                                }
+                            },
+                            failure = { lang.t("messages.queue.leave.notInQueue") },
+                        )
+                },
+            )
+            .let { sender.sendMessage(it) }
     }
 }

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/events/BrawlDeathEvent.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/events/BrawlDeathEvent.kt
@@ -8,6 +8,8 @@ import org.bukkit.entity.Player
 
 sealed class DeathReason {
     data object Void : DeathReason()
+
+    data object Damage : DeathReason()
 }
 
 class BrawlDeathEvent(val player: Player, val reason: DeathReason) : TwilightEvent() {

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/kits/BrawlKit.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/kits/BrawlKit.kt
@@ -39,6 +39,8 @@ open class BrawlKit(val id: String, val player: Player) : KoinComponent {
 
     protected var disguise: BrawlDisguise? = null
 
+    fun getMeleeDamage(): Double = kitData.meleeDamage
+
     fun getPassive(id: String): BrawlPassive? {
         return passives.find { it.id == id }
     }

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/BrawlMinigame.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/BrawlMinigame.kt
@@ -3,6 +3,7 @@ package dev.betrix.superSmashMobsBrawl.minigames
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.map
 import com.github.michaelbull.result.onFailure
 import com.github.michaelbull.result.onSuccess
 import com.github.michaelbull.result.unwrap
@@ -46,9 +47,11 @@ abstract class BrawlMinigame<TMinigameDef : MinigameDef>(
     private val langService: LangService by inject()
     private val plugin: SuperSmashMobsBrawl by inject()
 
-    protected val minigameData by lazy {
-        (dataService.getMinigame(minigameId))
-            ?: throw RuntimeException("Could not find minigame data for id $minigameId")
+    @Suppress("UNCHECKED_CAST")
+    protected val minigameData: TMinigameDef by lazy {
+        (dataService.getMinigame(minigameId)
+            ?: throw RuntimeException("Could not find minigame data for id $minigameId"))
+            as TMinigameDef
     }
 
     lateinit var brawlWorld: BrawlGameWorld
@@ -128,7 +131,7 @@ abstract class BrawlMinigame<TMinigameDef : MinigameDef>(
 
                 player.showTitle(title)
 
-                delay(1.seconds)
+                kotlinx.coroutines.delay(1.seconds)
             }
         }
 
@@ -182,11 +185,14 @@ abstract class BrawlMinigame<TMinigameDef : MinigameDef>(
         val voidLevel = brawlWorld.data.voidLevel
 
         runnables.add(
-            repeatingTask(5) {
+            gg.flyte.twilight.scheduler.repeatingTask(5) {
                 players.forEach { player ->
                     if (player.gameMode == GameMode.SURVIVAL && player.location.y <= voidLevel) {
                         plugin.logger.info("Player $player fell into the void")
-                        BrawlDeathEvent.call(player, DeathReason.Void)
+                        dev.betrix.superSmashMobsBrawl.events.BrawlDeathEvent.call(
+                            player,
+                            dev.betrix.superSmashMobsBrawl.events.DeathReason.Void,
+                        )
                     }
                 }
             }
@@ -213,6 +219,6 @@ abstract class BrawlMinigame<TMinigameDef : MinigameDef>(
 
         val selectedMap = validMaps.random()
 
-        return worldService.copyAndLoadWorld(selectedMap, gameId)
+        return worldService.copyAndLoadWorld(selectedMap, gameId).map { it as BrawlGameWorld }
     }
 }

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/BrawlMinigame.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/BrawlMinigame.kt
@@ -88,8 +88,7 @@ abstract class BrawlMinigame<TMinigameDef : MinigameDef>(
         listeners.add(
             event<SmashDamageEvent> {
                 // Only handle if this damage concerns players in this minigame
-                @Suppress("UNCHECKED_CAST")
-                if (!isValid(this@BrawlMinigame as BrawlMinigame<MinigameDef>)) return@event
+                if (!isValid(this@BrawlMinigame as BrawlMinigame<*>)) return@event
 
                 val victimPlayer = victim as? Player ?: return@event
 

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/BrawlMinigame.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/BrawlMinigame.kt
@@ -11,7 +11,9 @@ import com.github.shynixn.mccoroutine.bukkit.launch
 import dev.betrix.superSmashMobsBrawl.Manageable
 import dev.betrix.superSmashMobsBrawl.SuperSmashMobsBrawl
 import dev.betrix.superSmashMobsBrawl.events.BrawlDeathEvent
+import dev.betrix.superSmashMobsBrawl.events.Damager
 import dev.betrix.superSmashMobsBrawl.events.DeathReason
+import dev.betrix.superSmashMobsBrawl.events.SmashDamageEvent
 import dev.betrix.superSmashMobsBrawl.extensions.getEquidistant
 import dev.betrix.superSmashMobsBrawl.extensions.getFarthestFromPlayers
 import dev.betrix.superSmashMobsBrawl.extensions.location
@@ -22,6 +24,7 @@ import dev.betrix.superSmashMobsBrawl.models.MinigameState
 import dev.betrix.superSmashMobsBrawl.models.SpawnPoint
 import dev.betrix.superSmashMobsBrawl.models.brawlData.MinigameDef
 import dev.betrix.superSmashMobsBrawl.services.*
+import gg.flyte.twilight.event.event
 import gg.flyte.twilight.extension.feed
 import gg.flyte.twilight.extension.heal
 import gg.flyte.twilight.scheduler.repeatingTask
@@ -33,6 +36,8 @@ import net.kyori.adventure.text.Component
 import net.kyori.adventure.title.Title
 import org.bukkit.GameMode
 import org.bukkit.entity.Player
+import org.bukkit.event.entity.EntityDamageByEntityEvent
+import org.bukkit.event.entity.EntityDamageEvent
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
@@ -76,6 +81,62 @@ abstract class BrawlMinigame<TMinigameDef : MinigameDef>(
             BrawlDeathEvent.listen(this) {
                 plugin.logger.info("Player $player died")
                 plugin.launch { onPlayerDeath(player) }
+            }
+        )
+
+        // Apply damage within the context of this minigame
+        listeners.add(
+            event<SmashDamageEvent> {
+                // Only handle if this damage concerns players in this minigame
+                @Suppress("UNCHECKED_CAST")
+                if (!isValid(this@BrawlMinigame as BrawlMinigame<MinigameDef>)) return@event
+
+                val victimPlayer = victim as? Player ?: return@event
+
+                if (victimPlayer.gameMode != GameMode.SURVIVAL) return@event
+
+                val newHealth = (victimPlayer.health - damage).coerceAtLeast(0.0)
+
+                if (newHealth <= 0.0) {
+                    // Prevent vanilla death and route through our brawl death flow
+                    victimPlayer.health = 1.0
+                    BrawlDeathEvent.call(victimPlayer, DeathReason.Damage)
+                } else {
+                    victimPlayer.health = newHealth
+                }
+            }
+        )
+
+        // Translate melee damage into SmashDamageEvent within this minigame
+        listeners.add(
+            event<EntityDamageByEntityEvent> {
+                if (isCancelled) return@event
+
+                val victimPlayer = entity as? Player ?: return@event
+                val damagerPlayer = damager as? Player ?: return@event
+
+                if (!hasPlayer(victimPlayer) || !hasPlayer(damagerPlayer)) return@event
+
+                if (
+                    cause != EntityDamageEvent.DamageCause.ENTITY_ATTACK &&
+                        cause != EntityDamageEvent.DamageCause.ENTITY_SWEEP_ATTACK
+                )
+                    return@event
+
+                if (victimPlayer.gameMode != GameMode.SURVIVAL) return@event
+
+                // Cancel vanilla damage and route through SmashDamageEvent using kit melee damage
+                isCancelled = true
+
+                val attackerKit = kitService.getKitForPlayer(damagerPlayer)
+                val meleeDamage = attackerKit?.getMeleeDamage() ?: damage
+
+                SmashDamageEvent(
+                        victimPlayer,
+                        Damager.DamagerLivingEntity(damagerPlayer),
+                        meleeDamage,
+                    )
+                    .callEvent()
             }
         )
 

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/TeamBasedStocksMinigame.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/TeamBasedStocksMinigame.kt
@@ -38,6 +38,8 @@ open class TeamBasedStocksMinigame(
     }
 
     override suspend fun onPlayerDeath(player: Player) {
+        if (state == MinigameState.ENDED) return
+
         val team = playerToTeam[player]
         if (team == null) {
             // Fallback: if somehow no team, just use base behavior
@@ -98,7 +100,10 @@ open class TeamBasedStocksMinigame(
         if (state == MinigameState.ENDED) return
 
         val teamsWithStocks = teams.filter { it.stocks > 0 }
-        if (teamsWithStocks.size == 1) {
+        val teamsWithActivePlayer =
+            teams.filter { team -> team.players.any { it.gameMode == GameMode.SURVIVAL } }
+
+        if (teamsWithStocks.size == 1 && teamsWithActivePlayer.size <= 1) {
             endGame(teamsWithStocks.first())
         }
     }

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/TeamBasedStocksMinigame.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/TeamBasedStocksMinigame.kt
@@ -1,17 +1,127 @@
 package dev.betrix.superSmashMobsBrawl.minigames
 
+import com.github.michaelbull.result.onFailure
+import dev.betrix.superSmashMobsBrawl.SuperSmashMobsBrawl
+import dev.betrix.superSmashMobsBrawl.extensions.teleport
+import dev.betrix.superSmashMobsBrawl.models.MinigameState
 import dev.betrix.superSmashMobsBrawl.models.MinigameTeam
 import dev.betrix.superSmashMobsBrawl.models.brawlData.TeamBasedStocksMinigameDef
+import dev.betrix.superSmashMobsBrawl.services.HubService
+import dev.betrix.superSmashMobsBrawl.services.LangService
+import dev.betrix.superSmashMobsBrawl.services.MinigameService
+import gg.flyte.twilight.extension.feed
+import gg.flyte.twilight.extension.heal
+import org.bukkit.GameMode
 import org.bukkit.entity.Player
+import org.koin.core.component.inject
 
-open class TeamBasedStocksMinigame(minigameId: String, gameId: String, teams: List<MinigameTeam>) :
-    BrawlMinigame<TeamBasedStocksMinigameDef>(minigameId, gameId, teams.flatMap { it.players }) {
+open class TeamBasedStocksMinigame(
+    minigameId: String,
+    gameId: String,
+    private val teams: List<MinigameTeam>,
+) : BrawlMinigame<TeamBasedStocksMinigameDef>(minigameId, gameId, teams.flatMap { it.players }) {
+
+    private val hubService: HubService by inject()
+    private val langService: LangService by inject()
+    private val plugin: SuperSmashMobsBrawl by inject()
+    private val minigameService: MinigameService by inject()
+
+    private val playerToTeam: MutableMap<Player, MinigameTeam> = mutableMapOf()
+
+    override suspend fun initMinigame(): com.github.michaelbull.result.Result<Unit, Exception> {
+        // Initialize team stocks and mapping before calling base init (which teleports/assigns
+        // kits)
+        teams.forEach { team -> team.stocks = minigameData.stocks }
+        teams.forEach { team -> team.players.forEach { playerToTeam[it] = team } }
+
+        return super.initMinigame()
+    }
+
+    override suspend fun onPlayerDeath(player: Player) {
+        val team = playerToTeam[player]
+        if (team == null) {
+            // Fallback: if somehow no team, just use base behavior
+            super.onPlayerDeath(player)
+            return
+        }
+
+        // Consume a stock for this team
+        if (team.stocks > 0) {
+            team.stocks -= 1
+        }
+
+        // If after consuming, team has zero stocks, the dying player is eliminated and should not
+        // respawn
+        if (team.stocks == 0) {
+            eliminatePlayer(player)
+            checkForWinnerAndEndIfNeeded()
+            return
+        }
+
+        // Otherwise allow normal respawn flow
+        super.onPlayerDeath(player)
+        checkForWinnerAndEndIfNeeded()
+    }
 
     override fun canPlayerLeaveMinigame(player: Player): Boolean {
         return true
     }
 
     override fun onPlayerLeave(player: Player) {
-        TODO("Implement")
+        // Cleanup kit/passives using base behavior
+        super.onPlayerLeave(player)
+
+        // Remove from team roster mapping
+        playerToTeam[player]?.players?.remove(player)
+        playerToTeam.remove(player)
+
+        // Optional: if leaving causes only one team with stocks left, end the game
+        checkForWinnerAndEndIfNeeded()
+    }
+
+    private fun eliminatePlayer(player: Player) {
+        // Put player into spectator mode at the spectator spawn and stop further participation
+        if (!::brawlWorld.isInitialized) return
+
+        player.teleport(brawlWorld.data.spectatorSpawnPoint)
+        player.gameMode = GameMode.SPECTATOR
+        player.allowFlight = true
+        player.isFlying = true
+        player.feed()
+        player.heal()
+
+        // Ensure minigame kit effects are removed
+        super.onPlayerLeave(player)
+    }
+
+    private fun checkForWinnerAndEndIfNeeded() {
+        if (state == MinigameState.ENDED) return
+
+        val teamsWithStocks = teams.filter { it.stocks > 0 }
+        if (teamsWithStocks.size == 1) {
+            endGame(teamsWithStocks.first())
+        }
+    }
+
+    private fun endGame(winningTeam: MinigameTeam) {
+        if (state == MinigameState.ENDED) return
+        state = MinigameState.ENDED
+
+        val winners = winningTeam.players.joinToString(", ") { it.name }.ifBlank { "Unknown" }
+        val winMessage =
+            langService.t("messages.minigames.teamBasedStocks.winner") {
+                "winners" to winners
+                "minigameId" to minigameId
+            }
+
+        // Announce to everyone online
+        plugin.server.onlinePlayers.forEach { it.sendMessage(winMessage) }
+
+        // Teleport all participants back to the hub
+        players.forEach { p -> hubService.tryTeleportToDefaultHub(p).onFailure { /* ignore */ } }
+
+        // Remove this minigame instance and cleanup
+        minigameService.removeMinigameInstance(this)
+        teardown()
     }
 }

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/models/BrawlWorld.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/models/BrawlWorld.kt
@@ -8,6 +8,6 @@ sealed interface BrawlWorld {
     val world: World
 }
 
-data class BrawlGameWorld(override val world: World, val data: GameMapDef) : BrawlWorld()
+data class BrawlGameWorld(override val world: World, val data: GameMapDef) : BrawlWorld
 
-data class BrawlHubWorld(override val world: World, val data: HubMapDef) : BrawlWorld()
+data class BrawlHubWorld(override val world: World, val data: HubMapDef) : BrawlWorld

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/HubService.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/HubService.kt
@@ -49,11 +49,16 @@ object HubService : KoinComponent {
 
             val mapDef = dataService.getHubMap("blue_forest")!!
 
-            WorldService.copyAndLoadWorld<BrawlHubWorld>(mapDef)
+            WorldService.copyAndLoadWorld(mapDef)
                 .mapBoth(
                     success = { loadedWorld ->
+                        val hub = loadedWorld as? BrawlHubWorld
+                        if (hub == null) {
+                            plugin.logger.severe("Loaded world is not a hub world!")
+                            return@mapBoth
+                        }
                         plugin.logger.info("Successfully loaded default hub world")
-                        defaultHubWorld = loadedWorld
+                        defaultHubWorld = hub
                         registerEvents()
                     },
                     failure = { err ->

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/QueueService.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/QueueService.kt
@@ -3,7 +3,6 @@ package dev.betrix.superSmashMobsBrawl.services
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
-import com.github.shynixn.mccoroutine.bukkit.launch
 import dev.betrix.superSmashMobsBrawl.Manageable
 import dev.betrix.superSmashMobsBrawl.SuperSmashMobsBrawl
 import dev.betrix.superSmashMobsBrawl.minigames.PrototypingMinigame
@@ -167,13 +166,14 @@ object QueueService : Manageable(), KoinComponent {
 
                 val players: List<Player> = entriesToUse.map { it.player }
 
-                val teams: List<MinigameTeam> = (0 until amountOfTeams).map { teamIndex ->
-                    val startIndex = teamIndex * playersPerTeam
-                    val endIndex = startIndex + playersPerTeam
-                    val teamPlayers = players.subList(startIndex, endIndex).toMutableList()
-                    // Initial stocks value will be set during minigame init from definition
-                    MinigameTeam(teamPlayers, minigameDef.stocks)
-                }
+                val teams: List<MinigameTeam> =
+                    (0 until amountOfTeams).map { teamIndex ->
+                        val startIndex = teamIndex * playersPerTeam
+                        val endIndex = startIndex + playersPerTeam
+                        val teamPlayers = players.subList(startIndex, endIndex).toMutableList()
+                        // Initial stocks value will be set during minigame init from definition
+                        MinigameTeam(teamPlayers, minigameDef.stocks)
+                    }
 
                 val minigame = TeamBasedStocksMinigame(minigameDef.id, gameId, teams)
                 minigameService.handleMinigameSetup(minigame)

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/QueueService.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/QueueService.kt
@@ -7,6 +7,8 @@ import com.github.shynixn.mccoroutine.bukkit.launch
 import dev.betrix.superSmashMobsBrawl.Manageable
 import dev.betrix.superSmashMobsBrawl.SuperSmashMobsBrawl
 import dev.betrix.superSmashMobsBrawl.minigames.PrototypingMinigame
+import dev.betrix.superSmashMobsBrawl.minigames.TeamBasedStocksMinigame
+import dev.betrix.superSmashMobsBrawl.models.MinigameTeam
 import dev.betrix.superSmashMobsBrawl.models.brawlData.FfaMinigameDef
 import dev.betrix.superSmashMobsBrawl.models.brawlData.MinigameDef
 import dev.betrix.superSmashMobsBrawl.models.brawlData.TeamBasedStocksMinigameDef
@@ -140,7 +142,7 @@ object QueueService : Manageable(), KoinComponent {
     }
 
     private fun onMinigameCanStart(minigameDef: MinigameDef, queuedPlayers: List<QueueEntry>) {
-        val entriesToUse =
+        val entriesToUse: List<QueueEntry> =
             when (minigameDef) {
                 is TeamBasedStocksMinigameDef -> {
                     val playersPerTeam = minigameDef.playersPerTeam
@@ -160,18 +162,30 @@ object QueueService : Manageable(), KoinComponent {
 
         when (minigameDef) {
             is TeamBasedStocksMinigameDef -> {
-                // TODO: Implement team-based start
-                // val playersPerTeam = minigameDef.playersPerTeam
-                // val amountOfTeams = minigameDef.amountOfTeams
+                val playersPerTeam = minigameDef.playersPerTeam
+                val amountOfTeams = minigameDef.amountOfTeams
+
+                val players: List<Player> = entriesToUse.map { it.player }
+
+                val teams: List<MinigameTeam> = (0 until amountOfTeams).map { teamIndex ->
+                    val startIndex = teamIndex * playersPerTeam
+                    val endIndex = startIndex + playersPerTeam
+                    val teamPlayers = players.subList(startIndex, endIndex).toMutableList()
+                    // Initial stocks value will be set during minigame init from definition
+                    MinigameTeam(teamPlayers, minigameDef.stocks)
+                }
+
+                val minigame = TeamBasedStocksMinigame(minigameDef.id, gameId, teams)
+                minigameService.handleMinigameSetup(minigame)
             }
 
             is FfaMinigameDef -> {
-                val players = entriesToUse.map { it.player }
+                val players: List<Player> = entriesToUse.map { it.player }
 
                 when (minigameDef.id) {
                     "prototyping" -> {
                         val minigame = PrototypingMinigame(minigameDef.id, gameId, players)
-                        plugin.launch { minigame.initMinigame() }
+                        minigameService.handleMinigameSetup(minigame)
                     }
 
                     else -> {

--- a/plugin/src/main/resources/data/lang/en.yml
+++ b/plugin/src/main/resources/data/lang/en.yml
@@ -73,3 +73,5 @@ messages:
       unknown: "{lang:prefix} <#f2b8c6>An unknown error occurred. Please try again"
     respawn:
       timeLeft: "<#8bd5ff>{secondsLeft}"
+    teamBasedStocks:
+      winner: "{lang:prefix} <#e8edff>Team <#a6e3a1>{winners}</#a6e3a1> <#e8edff>won <#8bd5ff>{lang:minigames.{minigameId}.name}</#8bd5ff>!"


### PR DESCRIPTION
Complete `TeamBasedStocksMinigame` logic to manage team stocks, detect winners, and handle post-game actions.

---
<a href="https://cursor.com/background-agent?bcId=bc-fe23c62b-7093-4a8f-8c26-289f90f6524c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fe23c62b-7093-4a8f-8c26-289f90f6524c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Team-based stocks gameplay: per-team lives, automatic winner detection, clean end-game flow, and return to hub.
  - Unified combat in minigames: custom damage, controlled deaths/respawns, and melee damage derived from kits.
  - Improved queue leave: if not queued, leaving will also exit an active minigame when applicable.
- Localization
  - Added winner announcement message for team-based stocks.
- Bug Fixes
  - More robust hub world validation and world type handling to prevent misconfiguration-related issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->