### PR TITLE
Add iron armor to all kits

### DIFF
--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/AxiomLoggerHandler.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/AxiomLoggerHandler.kt
@@ -111,7 +111,7 @@ class AxiomLoggerHandler(private val plugin: SuperSmashMobsBrawl) : Handler() {
     }
 
     override fun close() {
-        runnable?.cancel()()
+        runnable?.cancel()
         flushQueue()
         axiomApiClient.close()
     }

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/kits/BrawlKit.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/kits/BrawlKit.kt
@@ -21,7 +21,9 @@ import gg.flyte.twilight.extension.feed
 import gg.flyte.twilight.extension.heal
 import java.util.logging.Logger
 import org.bukkit.GameMode
+import org.bukkit.Material
 import org.bukkit.entity.Player
+import org.bukkit.inventory.ItemStack
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
@@ -107,6 +109,19 @@ open class BrawlKit(val id: String, val player: Player) : KoinComponent {
         player.heal()
         player.feed()
 
+        // Equip armor if specified
+        kitData.armorItems?.let { armor ->
+            val helmetMat = armor.helmet?.let { Material.matchMaterial(it.uppercase()) }
+            val chestMat = armor.chestplate?.let { Material.matchMaterial(it.uppercase()) }
+            val legsMat = armor.leggings?.let { Material.matchMaterial(it.uppercase()) }
+            val bootsMat = armor.boots?.let { Material.matchMaterial(it.uppercase()) }
+
+            helmetMat?.let { player.inventory.helmet = ItemStack.of(it) }
+            chestMat?.let { player.inventory.chestplate = ItemStack.of(it) }
+            legsMat?.let { player.inventory.leggings = ItemStack.of(it) }
+            bootsMat?.let { player.inventory.boots = ItemStack.of(it) }
+        }
+
         player.sendDebugMessage("You have been given the $id kit")
     }
 
@@ -118,6 +133,14 @@ open class BrawlKit(val id: String, val player: Player) : KoinComponent {
 
         passives.forEach { it.teardown() }
         passives.clear()
+
+        // Remove armor given by this kit, if any
+        kitData.armorItems?.let {
+            player.inventory.helmet = null
+            player.inventory.chestplate = null
+            player.inventory.leggings = null
+            player.inventory.boots = null
+        }
 
         player.sendDebugMessage("The $id kit has been removed")
     }

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/models/brawlData/KitDef.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/models/brawlData/KitDef.kt
@@ -14,6 +14,7 @@ data class KitDef(
     val disguiseId: String? = null,
     val passives: List<KitPassiveDef> = emptyList(),
     val abilities: List<KitAbilityDef> = emptyList(),
+    val armorItems: KitArmorItemsDef? = null,
     val userFacing: Boolean = true,
 )
 
@@ -26,3 +27,11 @@ data class KitPassiveDef(val id: String, val overrides: KitPassiveDefOverrides? 
 data class KitAbilityDef(val id: String, val overrides: KitAbilityDefOverrides? = null)
 
 @Serializable data class KitAbilityDefOverrides(val metadata: Map<String, YamlScalar>? = null)
+
+@Serializable
+data class KitArmorItemsDef(
+    val helmet: String? = null,
+    val chestplate: String? = null,
+    val leggings: String? = null,
+    val boots: String? = null,
+)

--- a/plugin/src/main/resources/data/kits.yml
+++ b/plugin/src/main/resources/data/kits.yml
@@ -7,6 +7,11 @@ kits:
     knockbackMultiplier: 1.0
     passives:
       - id: double_jump
+    armorItems:
+      helmet: iron_helmet
+      chestplate: iron_chestplate
+      leggings: iron_leggings
+      boots: iron_boots
 
   # Creeper Kit
   - id: creeper
@@ -24,6 +29,11 @@ kits:
     abilities:
       - id: sulphur_bomb
       - id: explode
+    armorItems:
+      helmet: iron_helmet
+      chestplate: iron_chestplate
+      leggings: iron_leggings
+      boots: iron_boots
 
   # Skeleton Kit
   - id: skeleton
@@ -48,3 +58,8 @@ kits:
     abilities:
       - id: bone_explosion
       - id: roped_arrow
+    armorItems:
+      helmet: iron_helmet
+      chestplate: iron_chestplate
+      leggings: iron_leggings
+      boots: iron_boots

--- a/plugin/src/test/kotlin/dev/betrix/superSmashMobsBrawl/extensions/DurationExtensionsTest.kt
+++ b/plugin/src/test/kotlin/dev/betrix/superSmashMobsBrawl/extensions/DurationExtensionsTest.kt
@@ -6,23 +6,22 @@ import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
-class DurationExtensionsTest : DescribeSpec({
-    describe("Duration.ticks") {
-        it("converts milliseconds to ticks with truncation at 50ms per tick") {
-            0.milliseconds.ticks shouldBe 0L
-            49.milliseconds.ticks shouldBe 0L
-            50.milliseconds.ticks shouldBe 1L
-            99.milliseconds.ticks shouldBe 1L
-            100.milliseconds.ticks shouldBe 2L
+class DurationExtensionsTest :
+    DescribeSpec({
+        describe("Duration.ticks") {
+            it("converts milliseconds to ticks with truncation at 50ms per tick") {
+                0.milliseconds.ticks shouldBe 0L
+                49.milliseconds.ticks shouldBe 0L
+                50.milliseconds.ticks shouldBe 1L
+                99.milliseconds.ticks shouldBe 1L
+                100.milliseconds.ticks shouldBe 2L
+            }
+
+            it("converts common durations correctly") {
+                1.seconds.ticks shouldBe 20L
+                2.seconds.ticks shouldBe 40L
+                2500.milliseconds.ticks shouldBe 50L
+                1.minutes.ticks shouldBe 1200L
+            }
         }
-
-        it("converts common durations correctly") {
-            1.seconds.ticks shouldBe 20L
-            2.seconds.ticks shouldBe 40L
-            2500.milliseconds.ticks shouldBe 50L
-            1.minutes.ticks shouldBe 1200L
-        }
-    }
-})
-
-
+    })


### PR DESCRIPTION
Adds armor item support to kits, equipping all existing kits with full iron armor.

Includes a minor fix in `AxiomLoggerHandler.kt` to resolve a compile error that prevented the build from succeeding.

---
<a href="https://cursor.com/background-agent?bcId=bc-5a7fc662-f7cc-4b02-a65f-38f4d6122f50">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5a7fc662-f7cc-4b02-a65f-38f4d6122f50">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Kits can now include per-slot armor configuration. Players automatically equip specified armor on kit selection and it’s removed on teardown.
  - Hub, Creeper, and Skeleton kits now come with iron armor by default.

- Bug Fixes
  - Improved shutdown stability by preventing a duplicate cancellation during logging.

- Tests
  - Reformatted a test file for readability (no behavioral changes).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->