### PR TITLE
Migrate mm() calls to LangService.t()

### DIFF
--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/SuperSmashMobsBrawl.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/SuperSmashMobsBrawl.kt
@@ -16,7 +16,6 @@ import dev.betrix.superSmashMobsBrawl.services.KitService
 import dev.betrix.superSmashMobsBrawl.services.LangService
 import dev.betrix.superSmashMobsBrawl.services.MinigameService
 import dev.betrix.superSmashMobsBrawl.services.WorldService
-import dev.betrix.superSmashMobsBrawl.utils.mm
 import dev.rollczi.litecommands.LiteCommands
 import dev.rollczi.litecommands.bukkit.LiteBukkitFactory
 import gg.flyte.twilight.Twilight
@@ -34,11 +33,14 @@ import org.bukkit.event.inventory.InventoryInteractEvent
 import org.bukkit.event.inventory.InventoryMoveItemEvent
 import org.bukkit.event.player.PlayerDropItemEvent
 import org.bukkit.plugin.java.JavaPlugin
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
 import org.koin.dsl.module
 
-class SuperSmashMobsBrawl : SuspendingJavaPlugin() {
+class SuperSmashMobsBrawl : SuspendingJavaPlugin(), KoinComponent {
+    private val lang: LangService by inject()
     lateinit var liteCommands: LiteCommands<CommandSender>
     lateinit var twilight: Twilight
 
@@ -70,7 +72,7 @@ class SuperSmashMobsBrawl : SuspendingJavaPlugin() {
         HubProtectionService.registerEvents()
         DebugService.initialize(this)
 
-        server.motd(mm("The brawl reborn -- a wondrous thing!"))
+        server.motd(lang.t("messages.server.motd"))
 
         liteCommands =
             LiteBukkitFactory.builder(this)

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/SuperSmashMobsBrawl.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/SuperSmashMobsBrawl.kt
@@ -72,7 +72,7 @@ class SuperSmashMobsBrawl : SuspendingJavaPlugin(), KoinComponent {
         HubProtectionService.registerEvents()
         DebugService.initialize(this)
 
-        server.motd(lang.t("messages.server.motd"))
+        server.motd(lang.t("motd"))
 
         liteCommands =
             LiteBukkitFactory.builder(this)

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/abilities/BrawlAbility.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/abilities/BrawlAbility.kt
@@ -28,7 +28,7 @@ abstract class BrawlAbility(val id: String, val player: Player) : Manageable(), 
     private val dataService: DataService by inject()
     protected val minigameService: MinigameService by inject()
     protected val kitService: KitService by inject()
-    private val lang: LangService by inject()
+    protected val lang: LangService by inject()
 
     protected val abilityData by lazy {
         dataService.getAbility(id)

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/abilities/ExplodeAbility.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/abilities/ExplodeAbility.kt
@@ -7,7 +7,6 @@ import dev.betrix.superSmashMobsBrawl.events.SmashDamageEvent
 import dev.betrix.superSmashMobsBrawl.events.SmashDamageType
 import dev.betrix.superSmashMobsBrawl.extensions.doKnockback
 import dev.betrix.superSmashMobsBrawl.extensions.setVelocity
-import dev.betrix.superSmashMobsBrawl.utils.mm
 import gg.flyte.twilight.event.event
 import gg.flyte.twilight.extension.getNearbyEntities
 import gg.flyte.twilight.scheduler.repeatingTask
@@ -34,7 +33,7 @@ class ExplodeAbility(player: Player) : BrawlAbility("explode", player) {
     override fun canActivate(sendMessage: Boolean): Boolean {
         if (isExplodeActive) {
             if (sendMessage) {
-                player.sendMessage(mm("<red>Already charging explosion!</red>"))
+                player.sendMessage(lang.t("messages.abilities.explode.alreadyCharging"))
             }
             return false
         }

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/abilities/RopedArrowAbility.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/abilities/RopedArrowAbility.kt
@@ -19,7 +19,7 @@ class RopedArrowAbility(player: Player) : BrawlAbility("roped_arrow", player) {
         super.activate()
 
         val projectile =
-            ArrowProjectile(player, "Roped Arrow", arrowVelocityModifier)
+            ArrowProjectile(player, "abilities.roped_arrow.name", arrowVelocityModifier)
                 .onHitBlock { block, projectile ->
                     pullPlayerToLocation(block.location, projectile.velocityBeforeImpact)
                     true

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/commands/DebugCommand.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/commands/DebugCommand.kt
@@ -1,22 +1,25 @@
 package dev.betrix.superSmashMobsBrawl.commands
 
 import dev.betrix.superSmashMobsBrawl.services.DebugService
-import dev.betrix.superSmashMobsBrawl.utils.mm
+import dev.betrix.superSmashMobsBrawl.services.LangService
 import dev.rollczi.litecommands.annotations.command.Command
 import dev.rollczi.litecommands.annotations.context.Context
 import dev.rollczi.litecommands.annotations.description.Description
 import dev.rollczi.litecommands.annotations.execute.Execute
 import org.bukkit.command.CommandSender
 import org.bukkit.entity.Player
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
 
 @Command(name = "debug")
-class DebugCommand {
+class DebugCommand : KoinComponent {
+    private val lang: LangService by inject()
 
     @Execute
     @Description("Toggle debug mode on/off")
     fun execute(@Context sender: CommandSender) {
         if (sender !is Player) {
-            sender.sendMessage(mm("<red>Only players can use this command!</red>"))
+            sender.sendMessage(lang.t("messages.commands.onlyPlayers"))
             return
         }
 
@@ -30,9 +33,9 @@ class DebugCommand {
 
         val enabled = DebugService.toggleDebug(sender)
         if (enabled) {
-            sender.sendMessage(mm("<green>Debug mode enabled!</green>"))
+            sender.sendMessage(lang.t("messages.commands.debug.enabled"))
         } else {
-            sender.sendMessage(mm("<red>Debug mode disabled!</red>"))
+            sender.sendMessage(lang.t("messages.commands.debug.disabled"))
         }
     }
 }

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/commands/LeaveCommand.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/commands/LeaveCommand.kt
@@ -22,7 +22,7 @@ class LeaveCommand : KoinComponent {
     @Execute
     fun leave(@Context sender: CommandSender) {
         if (sender !is Player) {
-            sender.sendMessage(lang.t("messages.commands.onPlayers"))
+            sender.sendMessage(lang.t("messages.commands.onlyPlayers"))
             return
         }
 

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/commands/QueueCommand.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/commands/QueueCommand.kt
@@ -2,11 +2,11 @@ package dev.betrix.superSmashMobsBrawl.commands
 
 import com.github.michaelbull.result.mapBoth
 import dev.betrix.superSmashMobsBrawl.extensions.hasDebugEnabled
+import dev.betrix.superSmashMobsBrawl.extensions.sendDebugMessage
 import dev.betrix.superSmashMobsBrawl.models.brawlData.MinigameDef
 import dev.betrix.superSmashMobsBrawl.services.LangService
 import dev.betrix.superSmashMobsBrawl.services.MinigameService
 import dev.betrix.superSmashMobsBrawl.services.QueueService
-import dev.betrix.superSmashMobsBrawl.utils.mm
 import dev.rollczi.litecommands.annotations.argument.Arg
 import dev.rollczi.litecommands.annotations.command.Command
 import dev.rollczi.litecommands.annotations.context.Context
@@ -25,7 +25,7 @@ class QueueCommand : KoinComponent {
     @Execute
     fun queue(@Context sender: CommandSender) {
         if (sender !is Player) {
-            sender.sendMessage(lang.t("messages.commands.onPlayers"))
+            sender.sendMessage(lang.t("messages.commands.onlyPlayers"))
             return
         }
 
@@ -44,16 +44,14 @@ class QueueCommand : KoinComponent {
 
         // Example debug usage - show additional information if debug is enabled
         if (sender.hasDebugEnabled()) {
-            sender.sendMessage(
-                mm("<gray>[DEBUG] Queue status checked at ${System.currentTimeMillis()}</gray>")
-            )
+            sender.sendDebugMessage("Queue status checked at ${System.currentTimeMillis()}")
         }
     }
 
     @Execute
     fun queue(@Context sender: CommandSender, @Arg minigame: MinigameDef) {
         if (sender !is Player) {
-            sender.sendMessage(lang.t("messages.commands.onPlayers"))
+            sender.sendMessage(lang.t("messages.commands.onlyPlayers"))
             return
         }
 
@@ -72,7 +70,7 @@ class QueueCommand : KoinComponent {
     @Execute(name = "leave")
     fun queueLeave(@Context sender: CommandSender) {
         if (sender !is Player) {
-            sender.sendMessage(lang.t("messages.commands.onPlayers"))
+            sender.sendMessage(lang.t("messages.commands.onlyPlayers"))
             return
         }
 

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/passives/BarragePassive.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/passives/BarragePassive.kt
@@ -102,21 +102,20 @@ class BarragePassive(player: Player) : BrawlPassive("barrage", player) {
                     )
 
                 val arrow =
-                    ArrowProjectile(player, "Barrage Arrow", 3.0, spread).onHitLivingEntity {
-                        entity,
-                        arrow ->
-                        arrow.projectile?.remove()
+                    ArrowProjectile(player, "messages.projectiles.barrage_arrow", 3.0, spread)
+                        .onHitLivingEntity { entity, arrow ->
+                            arrow.projectile?.remove()
 
-                        SmashDamageEvent(
-                                entity,
-                                Damager.DamagerLivingEntity(player),
-                                6.0,
-                                damageType = SmashDamageType.Projectile,
-                            )
-                            .callEvent()
+                            SmashDamageEvent(
+                                    entity,
+                                    Damager.DamagerLivingEntity(player),
+                                    6.0,
+                                    damageType = SmashDamageType.Projectile,
+                                )
+                                .callEvent()
 
-                        true
-                    }
+                            true
+                        }
 
                 arrow.launch()
 

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/passives/HungerPassive.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/passives/HungerPassive.kt
@@ -2,7 +2,7 @@ package dev.betrix.superSmashMobsBrawl.passives
 
 import dev.betrix.superSmashMobsBrawl.events.Damager
 import dev.betrix.superSmashMobsBrawl.events.SmashDamageEvent
-import dev.betrix.superSmashMobsBrawl.utils.mm
+import dev.betrix.superSmashMobsBrawl.services.LangService
 import gg.flyte.twilight.event.event
 import gg.flyte.twilight.extension.feed
 import gg.flyte.twilight.scheduler.repeatingTask
@@ -11,8 +11,11 @@ import kotlin.math.min
 import org.bukkit.GameMode
 import org.bukkit.entity.Player
 import org.bukkit.event.entity.PlayerDeathEvent
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
 
-class HungerPassive(player: Player) : BrawlPassive("hunger", player) {
+class HungerPassive(player: Player) : BrawlPassive("hunger", player), KoinComponent {
+    private val lang: LangService by inject()
     private val hungerRestoreDelayMs = 250L
     private var hungerTicks = 0L
     private var lastHungerRestoreMs = System.currentTimeMillis()
@@ -59,7 +62,7 @@ class HungerPassive(player: Player) : BrawlPassive("hunger", player) {
         player.exhaustion = 0f
 
         if (player.foodLevel <= 0) {
-            player.sendMessage(mm("<red>Attack other players to restore hunger!</red>"))
+            player.sendMessage(lang.t("messages.passives.hunger.attackToRestore"))
 
             val damageEvent =
                 SmashDamageEvent(

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/projectiles/ArrowProjectile.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/projectiles/ArrowProjectile.kt
@@ -9,7 +9,7 @@ import org.bukkit.util.Vector
 
 class ArrowProjectile(
     override val owner: Player,
-    override val name: String = "Arrow",
+    override val name: String = "messages.projectiles.arrow",
     private val velocityMultiplier: Double,
     private val velocityAddend: Vector? = null,
 ) : BrawlProjectile(owner, name) {

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/projectiles/BrawlProjectile.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/projectiles/BrawlProjectile.kt
@@ -3,7 +3,7 @@ package dev.betrix.superSmashMobsBrawl.projectiles
 import dev.betrix.superSmashMobsBrawl.Manageable
 import dev.betrix.superSmashMobsBrawl.extensions.disguise
 import dev.betrix.superSmashMobsBrawl.extensions.isAirOrFoliage
-import dev.betrix.superSmashMobsBrawl.utils.mm
+import dev.betrix.superSmashMobsBrawl.services.LangService
 import gg.flyte.twilight.event.event
 import gg.flyte.twilight.scheduler.TwilightRunnable
 import gg.flyte.twilight.scheduler.repeatingTask
@@ -19,8 +19,12 @@ import org.bukkit.event.entity.ProjectileHitEvent
 import org.bukkit.util.BoundingBox
 import org.bukkit.util.RayTraceResult
 import org.bukkit.util.Vector
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
 
-abstract class BrawlProjectile(open val owner: Player, open val name: String) : Manageable() {
+abstract class BrawlProjectile(open val owner: Player, open val name: String) :
+    Manageable(), KoinComponent {
+    private val lang: LangService by inject()
     private var job: TwilightRunnable? = null
 
     @Volatile
@@ -71,7 +75,7 @@ abstract class BrawlProjectile(open val owner: Player, open val name: String) : 
 
     fun launch() {
         projectile = createProjectileEntity()
-        projectile?.customName(mm(name))
+        projectile?.customName(lang.t(name))
 
         if (projectile is Item) {
             val item = projectile as Item

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/projectiles/SulphurBombProjectile.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/projectiles/SulphurBombProjectile.kt
@@ -15,7 +15,7 @@ import org.bukkit.inventory.ItemStack
 class SulphurBombProjectile(
     override val owner: Player,
     private val onHit: (entity: LivingEntity?, projectile: Projectile?) -> Boolean,
-) : BrawlProjectile(owner, "Sulphur Bomb") {
+) : BrawlProjectile(owner, "abilities.sulphur_bomb.name") {
     override var projectileSize = 0.65
 
     private val projectileVelocityMultiplier = 1.55

--- a/plugin/src/main/resources/data/lang/en.yml
+++ b/plugin/src/main/resources/data/lang/en.yml
@@ -86,5 +86,4 @@ messages:
   projectiles:
     arrow: "Arrow"
     barrage_arrow: "Barrage Arrow"
-server:
-  motd: "The brawl reborn -- a wondrous thing!"
+motd: "The brawl reborn -- a wondrous thing!"

--- a/plugin/src/main/resources/data/lang/en.yml
+++ b/plugin/src/main/resources/data/lang/en.yml
@@ -42,6 +42,9 @@ messages:
     serverStarting: "Server is still starting! Please come back in a moment"
   commands:
     onlyPlayers: "<red>Only players can execute this command</red>"
+    debug:
+      enabled: "<green>Debug mode enabled!</green>"
+      disabled: "<red>Debug mode disabled!</red>"
   queue:
     leave:
       notInQueue: "{lang:prefix} <#f2b8c6>You are not currently in a queue<#e8edff>"
@@ -60,6 +63,8 @@ messages:
     use:
       success: "{lang:prefix} <#e8edff>Activated <#8bd5ff>{lang:abilities.{abilityId}.name}"
       cooldown: "{lang:prefix} <red>{lang:abilities.{abilityId}.name}</red> <#e8edff>is on cooldown for</#e8edff> <yellow>{seconds}s</yellow>!"
+    explode:
+      alreadyCharging: "<red>Already charging explosion!</red>"
   kits:
     select:
       success: "{lang:prefix} <#e8edff>You have selected kit <#8bd5ff>{lang:kits.{kitId}.name}"
@@ -75,3 +80,11 @@ messages:
       timeLeft: "<#8bd5ff>{secondsLeft}"
     teamBasedStocks:
       winner: "{lang:prefix} <#e8edff>Team <#a6e3a1>{winners}</#a6e3a1> <#e8edff>won <#8bd5ff>{lang:minigames.{minigameId}.name}</#8bd5ff>!"
+  passives:
+    hunger:
+      attackToRestore: "<red>Attack other players to restore hunger!</red>"
+  projectiles:
+    arrow: "Arrow"
+    barrage_arrow: "Barrage Arrow"
+server:
+  motd: "The brawl reborn -- a wondrous thing!"


### PR DESCRIPTION
Migrate player-facing messages from `mm()` to `LangService.t()` and add corresponding localization keys.

Fixes #95

---
<a href="https://cursor.com/background-agent?bcId=bc-a135f494-937d-4555-a6ca-8235f2e86362">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a135f494-937d-4555-a6ca-8235f2e86362">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added localization across the plugin: MOTD, commands, abilities, passives, and projectile names now use translated text.
  - Debug command and player-facing messages now return localized strings.
  - New English translations added for MOTD, debug toggles, abilities, passives, and projectiles.

- **Bug Fixes**
  - Non-player command error corrected to use the proper "onlyPlayers" message.
  - Removed remaining hard-coded messages to ensure consistent, translatable in-game text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->