### PR TITLE
Revert pvp mechanics to 1.8 style

### DIFF
--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/abilities/BrawlAbility.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/abilities/BrawlAbility.kt
@@ -159,9 +159,7 @@ abstract class BrawlAbility(val id: String, val player: Player) : Manageable(), 
 
         listeners.add(
             event<PlayerInteractEvent>(player) {
-                if (hand != EquipmentSlot.HAND) {
-                    return@event
-                }
+                if (hand != null && hand != EquipmentSlot.HAND) return@event
 
                 when (abilityData.usage) {
                     AbilityUsage.LEFT_CLICK -> {
@@ -207,7 +205,10 @@ abstract class BrawlAbility(val id: String, val player: Player) : Manageable(), 
 
     open fun activate() {
         setCooldown()
-        player.setCooldown(hotbarItemStack, (abilityData.cooldown * 20).toInt())
+        // Avoid client-side item cooldown visuals affecting combat rhythm; we keep only our timers
+        try {
+            player.setCooldown(hotbarItemStack, 0)
+        } catch (_: Throwable) {}
         player.sendMessage(lang.t("messages.abilities.use.success") { "abilityId" to id })
     }
 

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/kits/BrawlKit.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/kits/BrawlKit.kt
@@ -22,6 +22,7 @@ import gg.flyte.twilight.extension.heal
 import java.util.logging.Logger
 import org.bukkit.GameMode
 import org.bukkit.Material
+import org.bukkit.attribute.Attribute
 import org.bukkit.entity.Player
 import org.bukkit.inventory.ItemStack
 import org.koin.core.component.KoinComponent
@@ -121,6 +122,17 @@ open class BrawlKit(val id: String, val player: Player) : KoinComponent {
             legsMat?.let { player.inventory.leggings = ItemStack.of(it) }
             bootsMat?.let { player.inventory.boots = ItemStack.of(it) }
         }
+
+        // 1.8 PVP feel adjustments
+        try {
+            // Set high attack speed to remove 1.9+ cooldown
+            val attackSpeedAttr = Attribute.valueOf("GENERIC_ATTACK_SPEED")
+            player.getAttribute(attackSpeedAttr)?.baseValue = 16.0
+        } catch (_: Throwable) {}
+        // Clear offhand to avoid shield mechanics
+        try {
+            player.inventory.setItemInOffHand(ItemStack.of(Material.AIR))
+        } catch (_: Throwable) {}
 
         player.sendDebugMessage("You have been given the $id kit")
     }

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/BrawlMinigame.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/BrawlMinigame.kt
@@ -14,6 +14,7 @@ import dev.betrix.superSmashMobsBrawl.events.BrawlDeathEvent
 import dev.betrix.superSmashMobsBrawl.events.Damager
 import dev.betrix.superSmashMobsBrawl.events.DeathReason
 import dev.betrix.superSmashMobsBrawl.events.SmashDamageEvent
+import dev.betrix.superSmashMobsBrawl.extensions.doKnockback
 import dev.betrix.superSmashMobsBrawl.extensions.getEquidistant
 import dev.betrix.superSmashMobsBrawl.extensions.getFarthestFromPlayers
 import dev.betrix.superSmashMobsBrawl.extensions.location
@@ -95,7 +96,8 @@ abstract class BrawlMinigame<TMinigameDef : MinigameDef>(
 
                 if (victimPlayer.gameMode != GameMode.SURVIVAL) return@event
 
-                val newHealth = (victimPlayer.health - damage).coerceAtLeast(0.0)
+                val startingHealth = victimPlayer.health
+                val newHealth = (startingHealth - damage).coerceAtLeast(0.0)
 
                 if (newHealth <= 0.0) {
                     // Prevent vanilla death and route through our brawl death flow
@@ -103,6 +105,27 @@ abstract class BrawlMinigame<TMinigameDef : MinigameDef>(
                     BrawlDeathEvent.call(victimPlayer, DeathReason.Damage)
                 } else {
                     victimPlayer.health = newHealth
+                }
+
+                // Apply 1.8-style melee knockback only for melee damage (no special damage type)
+                if (damageType == null) {
+                    val damagerPlayer =
+                        (damager as? Damager.DamagerLivingEntity)?.livingEntity as? Player
+                    if (damagerPlayer != null) {
+                        val kitKnockbackMult =
+                            kitService.getKitForPlayer(damagerPlayer)?.let {
+                                dataService.getKit(it.id)?.knockbackMultiplier
+                            } ?: 1.0
+
+                        victimPlayer.noDamageTicks = 0
+                        victimPlayer.doKnockback(
+                            knockbackMultiplier * kitKnockbackMult,
+                            damage,
+                            startingHealth,
+                            damagerPlayer.location.toVector(),
+                            null,
+                        )
+                    }
                 }
             }
         )
@@ -156,6 +179,12 @@ abstract class BrawlMinigame<TMinigameDef : MinigameDef>(
         players.forEachIndexed { idx, player ->
             player.teleport(brawlWorld.world.location(spawnPoints[min(idx, spawnPoints.size)]))
             assignPlayerKit(player)
+            // Clear offhand to remove shield mechanics (1.8 feel)
+            try {
+                player.inventory.setItemInOffHand(
+                    org.bukkit.inventory.ItemStack.of(org.bukkit.Material.AIR)
+                )
+            } catch (_: Throwable) {}
         }
 
         state = MinigameState.STARTING


### PR DESCRIPTION
Implement 1.8-style combat mechanics for Super Smash Mobs Brawl PVP.

This PR removes 1.9+ attack cooldown by increasing attack speed, disables shields by clearing the offhand, and applies custom 1.8-like knockback on melee hits, bypassing vanilla damage immunity ticks for crisper combos.

---
<a href="https://cursor.com/background-agent?bcId=bc-d9e2f262-0b5f-4486-b96a-124a56ed1b80">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d9e2f262-0b5f-4486-b96a-124a56ed1b80">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced classic 1.8-style melee knockback for a more responsive PvP feel.
- Changes
  - Increased attack speed for faster combat.
  - Disabled off-hand/shield usage during matches.
  - Removed client-side item cooldown visuals; cooldowns are now fully server-controlled.
  - Improved ability activation reliability when interacting.
- Bug Fixes
  - More consistent damage application and death handling to prevent edge-case inconsistencies during combat.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->