### PR TITLE
Fix spectator flight bug in braw minigame

### DIFF
--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/BrawlMinigame.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/BrawlMinigame.kt
@@ -33,9 +33,11 @@ import java.time.Duration
 import kotlin.math.min
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.title.Title
 import org.bukkit.GameMode
+import org.bukkit.Sound
 import org.bukkit.entity.Player
 import org.bukkit.event.entity.EntityDamageByEntityEvent
 import org.bukkit.event.entity.EntityDamageEvent
@@ -57,7 +59,7 @@ abstract class BrawlMinigame<TMinigameDef : MinigameDef>(
     protected val minigameData: TMinigameDef by lazy {
         (dataService.getMinigame(minigameId)
             ?: throw RuntimeException("Could not find minigame data for id $minigameId"))
-            as TMinigameDef
+                as TMinigameDef
     }
 
     lateinit var brawlWorld: BrawlGameWorld
@@ -142,7 +144,7 @@ abstract class BrawlMinigame<TMinigameDef : MinigameDef>(
 
                 if (
                     cause != EntityDamageEvent.DamageCause.ENTITY_ATTACK &&
-                        cause != EntityDamageEvent.DamageCause.ENTITY_SWEEP_ATTACK
+                    cause != EntityDamageEvent.DamageCause.ENTITY_SWEEP_ATTACK
                 )
                     return@event
 
@@ -155,10 +157,10 @@ abstract class BrawlMinigame<TMinigameDef : MinigameDef>(
                 val meleeDamage = attackerKit?.getMeleeDamage() ?: damage
 
                 SmashDamageEvent(
-                        victimPlayer,
-                        Damager.DamagerLivingEntity(damagerPlayer),
-                        meleeDamage,
-                    )
+                    victimPlayer,
+                    Damager.DamagerLivingEntity(damagerPlayer),
+                    meleeDamage,
+                )
                     .callEvent()
             }
         )
@@ -184,7 +186,8 @@ abstract class BrawlMinigame<TMinigameDef : MinigameDef>(
                 player.inventory.setItemInOffHand(
                     org.bukkit.inventory.ItemStack.of(org.bukkit.Material.AIR)
                 )
-            } catch (_: Throwable) {}
+            } catch (_: Throwable) {
+            }
         }
 
         state = MinigameState.STARTING
@@ -194,6 +197,12 @@ abstract class BrawlMinigame<TMinigameDef : MinigameDef>(
 
     open suspend fun onPlayerDeath(player: Player) {
         kitService.unassignKit(player)?.let { assignedKits.removeIf { it.first == player } }
+
+        player.world.strikeLightningEffect(player.location)
+
+        gg.flyte.twilight.scheduler.delay(1) {
+            player.playSound(player.eyeLocation, Sound.ENTITY_PLAYER_HURT, 1f, 1f)
+        }
 
         if (minigameData.respawnDelaySeconds != null) {
             player.teleport(brawlWorld.data.spectatorSpawnPoint)
@@ -222,7 +231,7 @@ abstract class BrawlMinigame<TMinigameDef : MinigameDef>(
 
                 player.showTitle(title)
 
-                kotlinx.coroutines.delay(1.seconds)
+                delay(1.seconds)
             }
         }
 
@@ -230,7 +239,7 @@ abstract class BrawlMinigame<TMinigameDef : MinigameDef>(
             brawlWorld.data.spawnPoints.getFarthestFromPlayers(
                 players.filter { it != player },
                 brawlWorld.world,
-            ) ?: SpawnPoint(100.0, 100.0, 100.0)
+            ) ?: SpawnPoint(0.0, 100.0, 0.0)
 
         player.teleport(spawnPoint)
         player.feed()

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/BrawlMinigame.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/BrawlMinigame.kt
@@ -200,6 +200,7 @@ abstract class BrawlMinigame<TMinigameDef : MinigameDef>(
             player.gameMode = GameMode.SPECTATOR
             player.allowFlight = true
             player.isFlying = true
+            player.fallDistance = 0f
 
             val respawnDelay = minigameData.respawnDelaySeconds ?: 0
 

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/TeamBasedStocksMinigame.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/TeamBasedStocksMinigame.kt
@@ -89,6 +89,7 @@ open class TeamBasedStocksMinigame(
         player.gameMode = GameMode.SPECTATOR
         player.allowFlight = true
         player.isFlying = true
+        player.fallDistance = 0f
         player.feed()
         player.heal()
 

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/passives/DoubleJumpPassive.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/passives/DoubleJumpPassive.kt
@@ -84,7 +84,10 @@ class DoubleJumpPassive(player: Player) : BrawlPassive("double_jump", player) {
 
     override fun teardown() {
         super.teardown()
-        player.allowFlight = false
+        if (player.gameMode != GameMode.SPECTATOR && player.gameMode != GameMode.CREATIVE) {
+            player.isFlying = false
+            player.allowFlight = false
+        }
         canDoubleJump = false
     }
 }

--- a/plugin/src/main/resources/data/maps.yml
+++ b/plugin/src/main/resources/data/maps.yml
@@ -6,7 +6,7 @@ gameMaps:
     creators: [8ebcc57e-89df-4454-95b0-e7edc0071ac0]
     spectatorSpawnPoint:
       x: 0.0
-      y: 150.0
+      y: 110.0
       z: 45.0
       yaw: 0.0
       pitch: 0.0


### PR DESCRIPTION
Fix players falling and being unable to fly in spectator mode by adjusting spectator transition and double jump passive teardown.

---
<a href="https://cursor.com/background-agent?bcId=bc-461f257b-f3f4-43d2-b8d6-b88c90d7b77f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-461f257b-f3f4-43d2-b8d6-b88c90d7b77f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

