### PR TITLE
potion effect passive

### DIFF
--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/kits/BrawlKit.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/kits/BrawlKit.kt
@@ -88,6 +88,7 @@ open class BrawlKit(val id: String, val player: Player) : KoinComponent {
                     "arrow_recharge" -> ArrowRechargePassive(player)
                     "barrage" -> BarragePassive(player)
                     "stampede" -> StampedePassive(player)
+                    "potion_effect" -> PotionEffectPassive(player)
                     else -> {
                         logger.severe(
                             "No passive found with id ${it.id} reference on kit ${kitData.id}"

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/passives/BrawlPassive.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/passives/BrawlPassive.kt
@@ -1,6 +1,7 @@
 package dev.betrix.superSmashMobsBrawl.passives
 
 import dev.betrix.superSmashMobsBrawl.Manageable
+import dev.betrix.superSmashMobsBrawl.SuperSmashMobsBrawl
 import dev.betrix.superSmashMobsBrawl.extensions.getAs
 import dev.betrix.superSmashMobsBrawl.extensions.sendDebugMessage
 import dev.betrix.superSmashMobsBrawl.interfaces.MetadataAccessor
@@ -15,6 +16,7 @@ abstract class BrawlPassive(val id: String, val player: Player) : Manageable(), 
     protected val dataService: DataService by inject()
     protected val minigameService: MinigameService by inject()
     protected val kitService: KitService by inject()
+    protected val plugin: SuperSmashMobsBrawl by inject()
 
     protected val passiveData by lazy {
         dataService.getPassive(id)

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/passives/PotionEffectPassive.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/passives/PotionEffectPassive.kt
@@ -10,11 +10,12 @@ class PotionEffectPassive(player: Player) : BrawlPassive("potion_effect", player
 
     private val effectName = metadata.string("effect")
     private val effectLevel = metadata.int("level") ?: run {
-        plugin.logger.fine("metadata.level not set for $id passive, defaulting to 1")
-        1
+        plugin.logger.fine("metadata.level not set for $id passive, defaulting to 0")
+        0
     }
     private val isAmbient = metadata.boolean("isAmbient") ?: false
     private val showParticles = metadata.boolean("showParticles") ?: false
+    private val showIcon = metadata.boolean("showIcon") ?: true
 
     private val resolvedPotionEffect = when (effectName) {
         null -> null
@@ -23,7 +24,7 @@ class PotionEffectPassive(player: Player) : BrawlPassive("potion_effect", player
 
     override fun setup() {
         if (resolvedPotionEffect == null) {
-            plugin.logger.severe("Unable to resolve potion effect $effectName because it is either null or incorrect")
+            plugin.logger.severe("Unable to resolve potion effect $effectName for passive $id on kit ${kitData?.id ?: "unknown"}")
             return
         }
 
@@ -32,7 +33,8 @@ class PotionEffectPassive(player: Player) : BrawlPassive("potion_effect", player
             Int.MAX_VALUE,
             effectLevel,
             isAmbient,
-            showParticles
+            showParticles,
+            showIcon
         ))
 
         super.setup()

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/passives/PotionEffectPassive.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/passives/PotionEffectPassive.kt
@@ -1,0 +1,45 @@
+package dev.betrix.superSmashMobsBrawl.passives
+
+import net.kyori.adventure.key.Key
+import org.bukkit.NamespacedKey
+import org.bukkit.Registry
+import org.bukkit.entity.Player
+import org.bukkit.potion.PotionEffect
+
+class PotionEffectPassive(player: Player) : BrawlPassive("potion_effect", player) {
+
+    private val effectName = metadata.string("effect")
+    private val effectLevel = metadata.int("level") ?: run {
+        plugin.logger.fine("metadata.level not set for $id passive, defaulting to 1")
+        1
+    }
+    private val isAmbient = metadata.boolean("isAmbient") ?: false
+    private val showParticles = metadata.boolean("showParticles") ?: false
+
+    private val resolvedPotionEffect = when (effectName) {
+        null -> null
+        else -> Registry.EFFECT.get(NamespacedKey.minecraft(effectName.lowercase())) ?: Registry.EFFECT.get(Key.key(effectName))
+     }
+
+    override fun setup() {
+        if (resolvedPotionEffect == null) {
+            plugin.logger.severe("Unable to resolve potion effect $effectName because it is either null or incorrect")
+            return
+        }
+
+        player.addPotionEffect(PotionEffect(
+            resolvedPotionEffect,
+            Int.MAX_VALUE,
+            effectLevel,
+            isAmbient,
+            showParticles
+        ))
+
+        super.setup()
+    }
+
+    override fun teardown() {
+        resolvedPotionEffect?.let { player.removePotionEffect(resolvedPotionEffect) }
+        super.teardown()
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a new “Potion Effect” passive for kits, granting continuous potion effects to players.
  - Configurable options include effect type, level, ambient status, and particle visibility.
  - Effects persist while the kit is active and are cleanly removed afterward.

- Refactor
  - Internal improvements to passive handling and dependency setup (no user-facing changes).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->