### PR TITLE
Implement iron hook ability with projectile effects

### DIFF
--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/abilities/IronHookAbility.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/abilities/IronHookAbility.kt
@@ -1,0 +1,85 @@
+package dev.betrix.superSmashMobsBrawl.abilities
+
+import dev.betrix.superSmashMobsBrawl.events.Damager
+import dev.betrix.superSmashMobsBrawl.events.SmashDamageEvent
+import dev.betrix.superSmashMobsBrawl.events.SmashDamageType
+import dev.betrix.superSmashMobsBrawl.extensions.setVelocity
+import dev.betrix.superSmashMobsBrawl.projectiles.BrawlProjectile
+import dev.betrix.superSmashMobsBrawl.projectiles.IronHookProjectile
+import dev.betrix.superSmashMobsBrawl.projectiles.ProjectileAction
+import org.bukkit.Particle
+import org.bukkit.Sound
+import org.bukkit.entity.LivingEntity
+import org.bukkit.entity.Player
+import org.bukkit.util.Vector
+
+class IronHookAbility(player: Player) : BrawlAbility("iron_hook", player) {
+
+    private val projectileDamage = 4.0
+
+    private val activeProjectiles = mutableListOf<BrawlProjectile>()
+
+    override fun activate() {
+        throwProjectile()
+        super.activate()
+    }
+
+    override fun teardown() {
+        activeProjectiles.forEach { it.teardown() }
+        activeProjectiles.clear()
+        super.teardown()
+    }
+
+    private fun throwProjectile() {
+        val hookProjectile =
+            IronHookProjectile(player, "abilities.iron_hook.name")
+                .onTick { projectile ->
+                    val entity = projectile.projectileEntity ?: return@onTick
+                    // Ignite sound every tick
+                    entity.world.playSound(entity.location, Sound.ITEM_FLINTANDSTEEL_USE, 1f, 1f)
+                    // Crit particle every tick
+                    Particle.CRIT.builder()
+                        .location(entity.location)
+                        .count(1)
+                        .offset(0.0, 0.0, 0.0)
+                        .extra(0.0)
+                        .receivers(96, true)
+                        .spawn()
+                }
+                .onHitEntity { entity, projectile ->
+                    handleHookHit(entity, projectile)
+                    ProjectileAction.DESTROY
+                }
+                .onHitBlock { _, _ -> ProjectileAction.DESTROY }
+                .onTeardown { activeProjectiles.remove(it) }
+                .launch()
+
+        activeProjectiles.add(hookProjectile)
+    }
+
+    private fun handleHookHit(entity: LivingEntity, projectile: BrawlProjectile) {
+        SmashDamageEvent(
+                entity,
+                Damager.DamagerLivingEntity(player),
+                projectileDamage,
+                damageType = SmashDamageType.Projectile,
+            )
+            .callEvent()
+
+        pullEntityTowardsPlayer(entity, projectile.velocityBeforeImpact)
+    }
+
+    private fun pullEntityTowardsPlayer(target: LivingEntity, velocityBeforeImpact: Vector) {
+        val targetVector = target.location.toVector()
+        val playerVector = player.location.toVector()
+
+        val delta = playerVector.subtract(targetVector)
+        if (delta.lengthSquared() == 0.0) return
+
+        val trajectory = delta.normalize()
+        val mult = (velocityBeforeImpact.length() / 3.0).coerceAtLeast(0.2)
+
+        // Use the shared velocity helper for smoother motion towards the player
+        target.setVelocity(trajectory, 0.4 + mult, false, 0.0, 0.2 * mult, 1.2 * mult, true)
+    }
+}

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/disguises/BrawlDisguiseFactory.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/disguises/BrawlDisguiseFactory.kt
@@ -2,31 +2,32 @@ package dev.betrix.superSmashMobsBrawl.disguises
 
 import org.bukkit.entity.Player
 
-private val disguiseConstructors: Map<String, (Player) -> BrawlDisguise> = mapOf(
-    "creeper" to ::CreeperDisguise,
-    "skeleton" to ::SkeletonDisguise,
-    "cow" to ::CowDisguise,
-    "enderman" to ::EndermanDisguise,
-    "mooshroom" to ::MooshroomDisguise,
-    "mushroom_cow" to ::MooshroomDisguise,
-    "villager" to ::VillagerDisguise,
-    "sheep" to ::SheepDisguise,
-    "blaze" to ::BlazeDisguise,
-    "guardian" to ::GuardianDisguise,
-    "pig" to ::PigDisguise,
-    "horse" to ::HorseDisguise,
-    "zombie" to ::ZombieDisguise,
-    "wither_skeleton" to ::WitherSkeletonDisguise,
-    "witch" to ::WitchDisguise,
-    "magma_cube" to ::MagmaCubeDisguise,
-    "wolf" to ::WolfDisguise,
-    "snowman" to ::SnowmanDisguise,
-    "snow_golem" to ::SnowmanDisguise,
-    "squid" to ::SquidDisguise,
-    "slime" to ::SlimeDisguise,
-    "spider" to ::SpiderDisguise,
-    "iron_golem" to ::IronGolemDisguise,
-)
+private val disguiseConstructors: Map<String, (Player) -> BrawlDisguise> =
+    mapOf(
+        "creeper" to ::CreeperDisguise,
+        "skeleton" to ::SkeletonDisguise,
+        "cow" to ::CowDisguise,
+        "enderman" to ::EndermanDisguise,
+        "mooshroom" to ::MooshroomDisguise,
+        "mushroom_cow" to ::MooshroomDisguise,
+        "villager" to ::VillagerDisguise,
+        "sheep" to ::SheepDisguise,
+        "blaze" to ::BlazeDisguise,
+        "guardian" to ::GuardianDisguise,
+        "pig" to ::PigDisguise,
+        "horse" to ::HorseDisguise,
+        "zombie" to ::ZombieDisguise,
+        "wither_skeleton" to ::WitherSkeletonDisguise,
+        "witch" to ::WitchDisguise,
+        "magma_cube" to ::MagmaCubeDisguise,
+        "wolf" to ::WolfDisguise,
+        "snowman" to ::SnowmanDisguise,
+        "snow_golem" to ::SnowmanDisguise,
+        "squid" to ::SquidDisguise,
+        "slime" to ::SlimeDisguise,
+        "spider" to ::SpiderDisguise,
+        "iron_golem" to ::IronGolemDisguise,
+    )
 
 object BrawlDisguiseFactory {
     fun create(player: Player, id: String): BrawlDisguise? {

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/kits/BrawlKit.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/kits/BrawlKit.kt
@@ -51,6 +51,7 @@ open class BrawlKit(val id: String, val player: Player) : KoinComponent {
             abilities.add(
                 when (it.id) {
                     "sulphur_bomb" -> SulphurBombAbility(player)
+                    "iron_hook" -> IronHookAbility(player)
                     "explode" -> ExplodeAbility(player)
                     "roped_arrow" -> RopedArrowAbility(player)
                     "bone_explosion" -> BoneExplosionAbility(player)

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/passives/PotionEffectPassive.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/passives/PotionEffectPassive.kt
@@ -9,33 +9,42 @@ import org.bukkit.potion.PotionEffect
 class PotionEffectPassive(player: Player) : BrawlPassive("potion_effect", player) {
 
     private val effectName = metadata.string("effect")
-    private val effectLevel = metadata.int("level") ?: run {
-        plugin.logger.fine("metadata.level not set for $id passive, defaulting to 0")
-        0
-    }
+    private val effectLevel =
+        metadata.int("level")
+            ?: run {
+                plugin.logger.fine("metadata.level not set for $id passive, defaulting to 0")
+                0
+            }
     private val isAmbient = metadata.boolean("isAmbient") ?: false
     private val showParticles = metadata.boolean("showParticles") ?: false
     private val showIcon = metadata.boolean("showIcon") ?: true
 
-    private val resolvedPotionEffect = when (effectName) {
-        null -> null
-        else -> Registry.EFFECT.get(NamespacedKey.minecraft(effectName.lowercase())) ?: Registry.EFFECT.get(Key.key(effectName))
-     }
+    private val resolvedPotionEffect =
+        when (effectName) {
+            null -> null
+            else ->
+                Registry.EFFECT.get(NamespacedKey.minecraft(effectName.lowercase()))
+                    ?: Registry.EFFECT.get(Key.key(effectName))
+        }
 
     override fun setup() {
         if (resolvedPotionEffect == null) {
-            plugin.logger.severe("Unable to resolve potion effect $effectName for passive $id on kit ${kitData?.id ?: "unknown"}")
+            plugin.logger.severe(
+                "Unable to resolve potion effect $effectName for passive $id on kit ${kitData?.id ?: "unknown"}"
+            )
             return
         }
 
-        player.addPotionEffect(PotionEffect(
-            resolvedPotionEffect,
-            Int.MAX_VALUE,
-            effectLevel,
-            isAmbient,
-            showParticles,
-            showIcon
-        ))
+        player.addPotionEffect(
+            PotionEffect(
+                resolvedPotionEffect,
+                Int.MAX_VALUE,
+                effectLevel,
+                isAmbient,
+                showParticles,
+                showIcon,
+            )
+        )
 
         super.setup()
     }

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/projectiles/IronHookProjectile.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/projectiles/IronHookProjectile.kt
@@ -1,0 +1,18 @@
+package dev.betrix.superSmashMobsBrawl.projectiles
+
+import org.bukkit.Material
+import org.bukkit.entity.Item
+import org.bukkit.entity.Player
+import org.bukkit.inventory.ItemStack
+
+class IronHookProjectile(owner: Player, name: String = "messages.projectiles.custom") :
+    BrawlProjectile(owner, name) {
+
+    init {
+        projectileSize(0.45)
+        velocityMultiplier(1.6)
+    }
+
+    override fun createProjectileEntity(): Item =
+        owner.world.dropItem(owner.eyeLocation, ItemStack.of(Material.TRIPWIRE_HOOK)).apply {}
+}


### PR DESCRIPTION
Adds `IronHookAbility` and `IronHookProjectile` to introduce a new player-pulling and damaging ability.

---
<a href="https://cursor.com/background-agent?bcId=bc-3de356f0-19ad-4b3a-b91c-0fdd77560262">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3de356f0-19ad-4b3a-b91c-0fdd77560262">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

