### PR TITLE
kit switching in minigames that permit

### DIFF
--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/commands/KitCommand.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/commands/KitCommand.kt
@@ -1,8 +1,10 @@
 package dev.betrix.superSmashMobsBrawl.commands
 
 import dev.betrix.superSmashMobsBrawl.models.brawlData.KitDef
+import dev.betrix.superSmashMobsBrawl.models.brawlData.KitSwitchingMode
 import dev.betrix.superSmashMobsBrawl.services.KitService
 import dev.betrix.superSmashMobsBrawl.services.LangService
+import dev.betrix.superSmashMobsBrawl.services.MinigameService
 import dev.rollczi.litecommands.annotations.argument.Arg
 import dev.rollczi.litecommands.annotations.command.Command
 import dev.rollczi.litecommands.annotations.context.Context
@@ -16,6 +18,7 @@ import org.koin.core.component.inject
 class KitCommand : KoinComponent {
     private val lang: LangService by inject()
     private val kitService: KitService by inject()
+    private val minigameService: MinigameService by inject()
 
     @Execute
     fun kit(@Context player: Player) {
@@ -26,7 +29,17 @@ class KitCommand : KoinComponent {
     fun kit(@Context player: Player, @Arg kit: KitDef) {
         kitService.playerSelectKit(player, kit)
 
-        player.sendMessage(lang.t("messages.kits.select.success") { "kitId" to kit.id })
+        // Determine the message to show based on the player's current minigame
+        val currentMinigame = minigameService.getMinigameForPlayer(player)
+        val messageKey =
+            when (currentMinigame?.getKitSwitchingMode()) {
+                KitSwitchingMode.NEVER -> "messages.kits.select.success_never"
+                KitSwitchingMode.ON_DEATH -> "messages.kits.select.success_on_death"
+                KitSwitchingMode.IMMEDIATE -> "messages.kits.select.success_immediate"
+                null -> "messages.kits.select.success" // Player not in minigame
+            }
+
+        player.sendMessage(lang.t(messageKey) { "kitId" to kit.id })
         player.playSound(
             player.location,
             kit.selectionSound ?: Sound.ENTITY_EXPERIENCE_ORB_PICKUP,

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/events/PlayerSelectKitEvent.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/events/PlayerSelectKitEvent.kt
@@ -1,0 +1,24 @@
+package dev.betrix.superSmashMobsBrawl.events
+
+import dev.betrix.superSmashMobsBrawl.models.brawlData.KitDef
+import gg.flyte.twilight.event.TwilightEvent
+import org.bukkit.entity.Player
+
+class PlayerSelectKitEvent(
+    val player: Player,
+    val kit: KitDef,
+    var shouldSwitchImmediately: Boolean = false,
+) : TwilightEvent() {
+
+    companion object {
+        fun call(
+            player: Player,
+            kit: KitDef,
+            shouldSwitchImmediately: Boolean = false,
+        ): PlayerSelectKitEvent {
+            val event = PlayerSelectKitEvent(player, kit, shouldSwitchImmediately)
+            event.callEvent()
+            return event
+        }
+    }
+}

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/BrawlMinigame.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/BrawlMinigame.kt
@@ -109,6 +109,15 @@ abstract class BrawlMinigame<TMinigameDef : MinigameDef>(
                 if (!isPlayerInMinigame(player)) return@event
 
                 when (minigameData.kitSwitchingMode) {
+                    KitSwitchingMode.NEVER -> {
+                        // Just update the selection, no switching
+                    }
+
+                    KitSwitchingMode.ON_DEATH -> {
+                        // Update selection but don't switch immediately
+                        // The kit will be switched on respawn in onPlayerDeath
+                    }
+
                     KitSwitchingMode.IMMEDIATE -> {
                         if (shouldSwitchImmediately && !isPlayerRespawning(player)) {
                             // Switch kit immediately (but not if player is currently respawning)
@@ -245,6 +254,8 @@ abstract class BrawlMinigame<TMinigameDef : MinigameDef>(
             player.playSound(player.eyeLocation, Sound.ENTITY_PLAYER_HURT, 1f, 1f)
         }
 
+        var respawnSuccessful = false
+
         if (minigameData.respawnDelaySeconds != null) {
             player.teleport(brawlWorld!!.data.spectatorSpawnPoint)
             player.gameMode = GameMode.SPECTATOR
@@ -255,42 +266,54 @@ abstract class BrawlMinigame<TMinigameDef : MinigameDef>(
             // Mark player as respawning
             respawningPlayers.add(player.uniqueId)
 
-            val respawnDelay = minigameData.respawnDelaySeconds ?: 0
+            try {
+                val respawnDelay = minigameData.respawnDelaySeconds ?: 0
 
-            repeat(respawnDelay) { iteration ->
-                // Check if player is still in the minigame before each countdown step
+                repeat(respawnDelay) { iteration ->
+                    // Check if player is still in the minigame before each countdown step
+                    if (!isPlayerInMinigame(player)) {
+                        return
+                    }
+
+                    val secondsLeft = respawnDelay - iteration
+
+                    val title =
+                        Title.title(
+                            langService.t("messages.minigames.respawn.timeLeft") {
+                                "secondsLeft" to secondsLeft
+                            },
+                            Component.empty(),
+                            Title.Times.times(
+                                Duration.ofMillis(250),
+                                Duration.ofMillis(500),
+                                Duration.ofMillis(250),
+                            ),
+                        )
+
+                    player.showTitle(title)
+
+                    delay(1.seconds)
+                }
+
+                // Final check before respawning
                 if (!isPlayerInMinigame(player)) {
                     return
                 }
 
-                val secondsLeft = respawnDelay - iteration
-
-                val title =
-                    Title.title(
-                        langService.t("messages.minigames.respawn.timeLeft") {
-                            "secondsLeft" to secondsLeft
-                        },
-                        Component.empty(),
-                        Title.Times.times(
-                            Duration.ofMillis(250),
-                            Duration.ofMillis(500),
-                            Duration.ofMillis(250),
-                        ),
-                    )
-
-                player.showTitle(title)
-
-                delay(1.seconds)
-            }
-
-            // Final check before respawning
-            if (!isPlayerInMinigame(player)) {
-                return
+                // If we reach here, respawn was successful
+                respawnSuccessful = true
+            } finally {
+                // Only remove from respawning if respawn failed (player left during countdown)
+                if (!respawnSuccessful) {
+                    respawningPlayers.remove(player.uniqueId)
+                }
             }
         }
 
-        // Remove player from respawning state before respawning
-        respawningPlayers.remove(player.uniqueId)
+        // Remove player from respawning state before respawning (successful case)
+        if (respawnSuccessful || minigameData.respawnDelaySeconds == null) {
+            respawningPlayers.remove(player.uniqueId)
+        }
 
         val spawnPoint =
             brawlWorld!!

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/BrawlMinigame.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/BrawlMinigame.kt
@@ -13,6 +13,7 @@ import dev.betrix.superSmashMobsBrawl.SuperSmashMobsBrawl
 import dev.betrix.superSmashMobsBrawl.events.BrawlDeathEvent
 import dev.betrix.superSmashMobsBrawl.events.Damager
 import dev.betrix.superSmashMobsBrawl.events.DeathReason
+import dev.betrix.superSmashMobsBrawl.events.PlayerSelectKitEvent
 import dev.betrix.superSmashMobsBrawl.events.SmashDamageEvent
 import dev.betrix.superSmashMobsBrawl.extensions.doKnockback
 import dev.betrix.superSmashMobsBrawl.extensions.getEquidistant
@@ -24,6 +25,7 @@ import dev.betrix.superSmashMobsBrawl.models.BrawlGameWorld
 import dev.betrix.superSmashMobsBrawl.models.MinigamePlayer
 import dev.betrix.superSmashMobsBrawl.models.MinigameState
 import dev.betrix.superSmashMobsBrawl.models.SpawnPoint
+import dev.betrix.superSmashMobsBrawl.models.brawlData.KitSwitchingMode
 import dev.betrix.superSmashMobsBrawl.models.brawlData.MinigameDef
 import dev.betrix.superSmashMobsBrawl.services.*
 import gg.flyte.twilight.event.event
@@ -60,7 +62,7 @@ abstract class BrawlMinigame<TMinigameDef : MinigameDef>(
     protected val minigameData: TMinigameDef by lazy {
         (dataService.getMinigame(minigameId)
             ?: throw RuntimeException("Could not find minigame data for id $minigameId"))
-            as TMinigameDef
+                as TMinigameDef
     }
 
     var brawlWorld: BrawlGameWorld? = null
@@ -74,9 +76,22 @@ abstract class BrawlMinigame<TMinigameDef : MinigameDef>(
     /** Tracks players who disconnected while in this minigame */
     protected val disconnectedPlayers = mutableSetOf<UUID>()
 
+    /** Tracks players who are currently dead and waiting to respawn */
+    protected val respawningPlayers = mutableSetOf<UUID>()
+
     /** Determine if a passive can be used in a minigame */
     fun isPassiveValid(id: String): Boolean {
         return minigameData.isPassiveValid(id)
+    }
+
+    /** Get the kit switching mode for this minigame */
+    fun getKitSwitchingMode(): KitSwitchingMode {
+        return minigameData.kitSwitchingMode
+    }
+
+    /** Check if a player is currently dead and waiting to respawn */
+    fun isPlayerRespawning(player: Player): Boolean {
+        return respawningPlayers.contains(player.uniqueId)
     }
 
     open suspend fun initMinigame(): Result<Unit, Exception> {
@@ -84,6 +99,24 @@ abstract class BrawlMinigame<TMinigameDef : MinigameDef>(
             BrawlDeathEvent.listen(this) {
                 plugin.logger.info("Player $player died")
                 plugin.launch { onPlayerDeath(player) }
+            }
+        )
+
+        // Handle kit selection events
+        listeners.add(
+            event<PlayerSelectKitEvent> {
+                // Only handle if this player is in this minigame
+                if (!isPlayerInMinigame(player)) return@event
+
+                when (minigameData.kitSwitchingMode) {
+                    KitSwitchingMode.IMMEDIATE -> {
+                        if (shouldSwitchImmediately && !isPlayerRespawning(player)) {
+                            // Switch kit immediately (but not if player is currently respawning)
+                            kitService.unassignKit(player)
+                            kitService.assignKit(player, kit.id)
+                        }
+                    }
+                }
             }
         )
 
@@ -145,7 +178,7 @@ abstract class BrawlMinigame<TMinigameDef : MinigameDef>(
 
                 if (
                     cause != EntityDamageEvent.DamageCause.ENTITY_ATTACK &&
-                        cause != EntityDamageEvent.DamageCause.ENTITY_SWEEP_ATTACK
+                    cause != EntityDamageEvent.DamageCause.ENTITY_SWEEP_ATTACK
                 )
                     return@event
 
@@ -158,10 +191,10 @@ abstract class BrawlMinigame<TMinigameDef : MinigameDef>(
                 val meleeDamage = attackerKit?.getMeleeDamage() ?: damage
 
                 SmashDamageEvent(
-                        victimPlayer,
-                        Damager.DamagerLivingEntity(damagerPlayer),
-                        meleeDamage,
-                    )
+                    victimPlayer,
+                    Damager.DamagerLivingEntity(damagerPlayer),
+                    meleeDamage,
+                )
                     .callEvent()
             }
         )
@@ -189,7 +222,8 @@ abstract class BrawlMinigame<TMinigameDef : MinigameDef>(
                 player.player.inventory.setItemInOffHand(
                     org.bukkit.inventory.ItemStack.of(org.bukkit.Material.AIR)
                 )
-            } catch (_: Throwable) {}
+            } catch (_: Throwable) {
+            }
         }
 
         state = MinigameState.STARTING
@@ -217,6 +251,9 @@ abstract class BrawlMinigame<TMinigameDef : MinigameDef>(
             player.allowFlight = true
             player.isFlying = true
             player.fallDistance = 0f
+
+            // Mark player as respawning
+            respawningPlayers.add(player.uniqueId)
 
             val respawnDelay = minigameData.respawnDelaySeconds ?: 0
 
@@ -252,6 +289,9 @@ abstract class BrawlMinigame<TMinigameDef : MinigameDef>(
             }
         }
 
+        // Remove player from respawning state before respawning
+        respawningPlayers.remove(player.uniqueId)
+
         val spawnPoint =
             brawlWorld!!
                 .data
@@ -269,12 +309,28 @@ abstract class BrawlMinigame<TMinigameDef : MinigameDef>(
         player.feed()
         player.heal()
         player.gameMode = GameMode.SURVIVAL
+
+        // Handle kit switching on respawn for both ON_DEATH and IMMEDIATE modes
+        // (IMMEDIATE mode needs this for cases where kit was selected during spectator countdown)
+        if (
+            minigameData.kitSwitchingMode == KitSwitchingMode.ON_DEATH ||
+            minigameData.kitSwitchingMode == KitSwitchingMode.IMMEDIATE
+        ) {
+            val currentKit = kitService.getKitForPlayer(player)
+            val selectedKit = kitService.currentSelectedKitForPlayer(player)
+
+            if (currentKit?.id != selectedKit.id) {
+                // Unassign current kit and assign the selected one
+                kitService.unassignKit(player)
+            }
+        }
+
         assignPlayerKit(player)
     }
 
     fun isPlayerInMinigame(player: Player): Boolean {
         return players.find { it.player == player } != null &&
-            !disconnectedPlayers.contains(player.uniqueId)
+                !disconnectedPlayers.contains(player.uniqueId)
     }
 
     open fun canPlayerLeaveMinigame(player: Player): Boolean {
@@ -287,6 +343,8 @@ abstract class BrawlMinigame<TMinigameDef : MinigameDef>(
         if (!disconnectedPlayers.contains(player.uniqueId)) {
             disconnectedPlayers.add(player.uniqueId)
         }
+        // Clean up respawning state if player leaves while respawning
+        respawningPlayers.remove(player.uniqueId)
     }
 
     /** Called when a player disconnects from the server while in this minigame */
@@ -350,8 +408,8 @@ abstract class BrawlMinigame<TMinigameDef : MinigameDef>(
             players.filter { player ->
                 val bukkitPlayer = player.player
                 bukkitPlayer.isOnline &&
-                    !disconnectedPlayers.contains(bukkitPlayer.uniqueId) &&
-                    bukkitPlayer.gameMode != GameMode.SPECTATOR
+                        !disconnectedPlayers.contains(bukkitPlayer.uniqueId) &&
+                        bukkitPlayer.gameMode != GameMode.SPECTATOR
             }
 
         // End minigame if no active players remain
@@ -389,7 +447,7 @@ abstract class BrawlMinigame<TMinigameDef : MinigameDef>(
                 players.forEach { player ->
                     if (
                         player.player.gameMode == GameMode.SURVIVAL &&
-                            player.player.location.y <= voidLevel
+                        player.player.location.y <= voidLevel
                     ) {
                         plugin.logger.info("Player $player fell into the void")
                         BrawlDeathEvent.call(player.player, DeathReason.Void)

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/BrawlMinigame.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/BrawlMinigame.kt
@@ -62,7 +62,7 @@ abstract class BrawlMinigame<TMinigameDef : MinigameDef>(
     protected val minigameData: TMinigameDef by lazy {
         (dataService.getMinigame(minigameId)
             ?: throw RuntimeException("Could not find minigame data for id $minigameId"))
-                as TMinigameDef
+            as TMinigameDef
     }
 
     var brawlWorld: BrawlGameWorld? = null
@@ -109,15 +109,6 @@ abstract class BrawlMinigame<TMinigameDef : MinigameDef>(
                 if (!isPlayerInMinigame(player)) return@event
 
                 when (minigameData.kitSwitchingMode) {
-                    KitSwitchingMode.NEVER -> {
-                        // Just update the selection, no switching
-                    }
-
-                    KitSwitchingMode.ON_DEATH -> {
-                        // Update selection but don't switch immediately
-                        // The kit will be switched on respawn in onPlayerDeath
-                    }
-
                     KitSwitchingMode.IMMEDIATE -> {
                         if (shouldSwitchImmediately && !isPlayerRespawning(player)) {
                             // Switch kit immediately (but not if player is currently respawning)
@@ -125,6 +116,8 @@ abstract class BrawlMinigame<TMinigameDef : MinigameDef>(
                             kitService.assignKit(player, kit.id)
                         }
                     }
+
+                    else -> {}
                 }
             }
         )
@@ -187,7 +180,7 @@ abstract class BrawlMinigame<TMinigameDef : MinigameDef>(
 
                 if (
                     cause != EntityDamageEvent.DamageCause.ENTITY_ATTACK &&
-                    cause != EntityDamageEvent.DamageCause.ENTITY_SWEEP_ATTACK
+                        cause != EntityDamageEvent.DamageCause.ENTITY_SWEEP_ATTACK
                 )
                     return@event
 
@@ -200,10 +193,10 @@ abstract class BrawlMinigame<TMinigameDef : MinigameDef>(
                 val meleeDamage = attackerKit?.getMeleeDamage() ?: damage
 
                 SmashDamageEvent(
-                    victimPlayer,
-                    Damager.DamagerLivingEntity(damagerPlayer),
-                    meleeDamage,
-                )
+                        victimPlayer,
+                        Damager.DamagerLivingEntity(damagerPlayer),
+                        meleeDamage,
+                    )
                     .callEvent()
             }
         )
@@ -231,8 +224,7 @@ abstract class BrawlMinigame<TMinigameDef : MinigameDef>(
                 player.player.inventory.setItemInOffHand(
                     org.bukkit.inventory.ItemStack.of(org.bukkit.Material.AIR)
                 )
-            } catch (_: Throwable) {
-            }
+            } catch (_: Throwable) {}
         }
 
         state = MinigameState.STARTING
@@ -337,7 +329,7 @@ abstract class BrawlMinigame<TMinigameDef : MinigameDef>(
         // (IMMEDIATE mode needs this for cases where kit was selected during spectator countdown)
         if (
             minigameData.kitSwitchingMode == KitSwitchingMode.ON_DEATH ||
-            minigameData.kitSwitchingMode == KitSwitchingMode.IMMEDIATE
+                minigameData.kitSwitchingMode == KitSwitchingMode.IMMEDIATE
         ) {
             val currentKit = kitService.getKitForPlayer(player)
             val selectedKit = kitService.currentSelectedKitForPlayer(player)
@@ -353,7 +345,7 @@ abstract class BrawlMinigame<TMinigameDef : MinigameDef>(
 
     fun isPlayerInMinigame(player: Player): Boolean {
         return players.find { it.player == player } != null &&
-                !disconnectedPlayers.contains(player.uniqueId)
+            !disconnectedPlayers.contains(player.uniqueId)
     }
 
     open fun canPlayerLeaveMinigame(player: Player): Boolean {
@@ -431,8 +423,8 @@ abstract class BrawlMinigame<TMinigameDef : MinigameDef>(
             players.filter { player ->
                 val bukkitPlayer = player.player
                 bukkitPlayer.isOnline &&
-                        !disconnectedPlayers.contains(bukkitPlayer.uniqueId) &&
-                        bukkitPlayer.gameMode != GameMode.SPECTATOR
+                    !disconnectedPlayers.contains(bukkitPlayer.uniqueId) &&
+                    bukkitPlayer.gameMode != GameMode.SPECTATOR
             }
 
         // End minigame if no active players remain
@@ -470,7 +462,7 @@ abstract class BrawlMinigame<TMinigameDef : MinigameDef>(
                 players.forEach { player ->
                     if (
                         player.player.gameMode == GameMode.SURVIVAL &&
-                        player.player.location.y <= voidLevel
+                            player.player.location.y <= voidLevel
                     ) {
                         plugin.logger.info("Player $player fell into the void")
                         BrawlDeathEvent.call(player.player, DeathReason.Void)

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/models/brawlData/MinigameDef.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/models/brawlData/MinigameDef.kt
@@ -4,7 +4,15 @@ import com.charleskorn.kaml.YamlScalar
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
-@Serializable data class MinigameDefFile(val minigames: List<MinigameDef>)
+@Serializable
+enum class KitSwitchingMode {
+    NEVER,
+    ON_DEATH,
+    IMMEDIATE,
+}
+
+@Serializable
+data class MinigameDefFile(val minigames: List<MinigameDef>)
 
 @Serializable
 sealed class MinigameDef {
@@ -18,6 +26,7 @@ sealed class MinigameDef {
     abstract val respawnDelaySeconds: Int?
     abstract val overrides: MinigameDefOverrides?
     abstract val allowRejoinAfterLeave: Boolean
+    abstract val kitSwitchingMode: KitSwitchingMode
 
     fun isPassiveValid(passiveId: String): Boolean {
         if (passiveBlacklist?.contains(passiveId) == true) {
@@ -45,9 +54,9 @@ data class FfaMinigameDef(
     override val respawnDelaySeconds: Int? = null,
     override val overrides: MinigameDefOverrides? = null,
     override val allowRejoinAfterLeave: Boolean = true,
+    override val kitSwitchingMode: KitSwitchingMode = KitSwitchingMode.NEVER,
     val minPlayers: Int,
     val maxPlayers: Int,
-    val allowKitSwitching: Boolean,
 ) : MinigameDef()
 
 @Serializable
@@ -63,6 +72,7 @@ data class TeamBasedStocksMinigameDef(
     override val respawnDelaySeconds: Int? = null,
     override val overrides: MinigameDefOverrides? = null,
     override val allowRejoinAfterLeave: Boolean = true,
+    override val kitSwitchingMode: KitSwitchingMode = KitSwitchingMode.NEVER,
     val playersPerTeam: Int,
     val amountOfTeams: Int,
     val stocks: Int,

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/models/brawlData/MinigameDef.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/models/brawlData/MinigameDef.kt
@@ -11,8 +11,7 @@ enum class KitSwitchingMode {
     IMMEDIATE,
 }
 
-@Serializable
-data class MinigameDefFile(val minigames: List<MinigameDef>)
+@Serializable data class MinigameDefFile(val minigames: List<MinigameDef>)
 
 @Serializable
 sealed class MinigameDef {

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/KitService.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/KitService.kt
@@ -4,9 +4,11 @@ import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.shynixn.mccoroutine.bukkit.launch
+import dev.betrix.superSmashMobsBrawl.events.PlayerSelectKitEvent
 import dev.betrix.superSmashMobsBrawl.extensions.event
 import dev.betrix.superSmashMobsBrawl.kits.BrawlKit
 import dev.betrix.superSmashMobsBrawl.models.brawlData.KitDef
+import dev.betrix.superSmashMobsBrawl.models.brawlData.KitSwitchingMode
 import gg.flyte.twilight.event.event
 import gg.flyte.twilight.gui.GUI.Companion.openInventory
 import gg.flyte.twilight.gui.gui
@@ -30,6 +32,7 @@ object KitService : KoinComponent {
     private val lang: LangService by inject()
     private val plugin: JavaPlugin by inject()
     private val dataService: DataService by inject()
+    private val minigameService: MinigameService by inject()
 
     private val playerSelectedKits = ConcurrentHashMap<Player, String>() // kit id
     private val assignedBrawlKits = ConcurrentHashMap<Player, BrawlKit>()
@@ -43,6 +46,14 @@ object KitService : KoinComponent {
 
     fun playerSelectKit(player: Player, kit: KitDef) {
         playerSelectedKits[player] = kit.id
+
+        // Determine if the player should switch kits immediately based on their current minigame
+        val currentMinigame = minigameService.getMinigameForPlayer(player)
+        val shouldSwitchImmediately =
+            currentMinigame?.getKitSwitchingMode() == KitSwitchingMode.IMMEDIATE
+
+        // Dispatch the event
+        PlayerSelectKitEvent.call(player, kit, shouldSwitchImmediately)
     }
 
     fun currentSelectedKitForPlayer(player: Player): KitDef {

--- a/plugin/src/main/resources/data/lang/en.yml
+++ b/plugin/src/main/resources/data/lang/en.yml
@@ -84,6 +84,9 @@ messages:
   kits:
     select:
       success: "{lang:prefix} <#e8edff>You have selected kit <#8bd5ff>{lang:kits.{kitId}.name}"
+      success_never: "{lang:prefix} <#e8edff>You have selected kit <#8bd5ff>{lang:kits.{kitId}.name}<#e8edff>, but kit switching is disabled in this minigame"
+      success_on_death: "{lang:prefix} <#e8edff>You have selected kit <#8bd5ff>{lang:kits.{kitId}.name}<#e8edff>. Your kit will switch after you respawn"
+      success_immediate: "{lang:prefix} <#e8edff>You have selected and switched to kit <#8bd5ff>{lang:kits.{kitId}.name}"
   players:
     joinServer: "{lang:prefix} <#8bd5ff>{playerName} <#e8edff>has joined the server"
   minigames:

--- a/plugin/src/main/resources/data/minigames.yml
+++ b/plugin/src/main/resources/data/minigames.yml
@@ -5,7 +5,7 @@ minigames:
     isHidden: false
     minPlayers: 1
     maxPlayers: 4
-    allowKitSwitching: true
+    kitSwitchingMode: immediate
     allowParties: true
     passiveBlacklist: [hunger]
     respawnDelaySeconds: 5


### PR DESCRIPTION
### TL;DR

Added configurable kit switching modes to minigames with immediate, on-death, and never options.

### What changed?

- Added a new `KitSwitchingMode` enum with three options: `NEVER`, `ON_DEATH`, and `IMMEDIATE`
- Replaced the boolean `allowKitSwitching` with the more flexible `kitSwitchingMode` in minigame definitions
- Created a new `PlayerSelectKitEvent` to handle kit selection events
- Updated the `BrawlMinigame` class to track respawning players and handle kit switching based on the configured mode
- Added different success messages for each kit switching mode to provide clear feedback to players
- Updated the kit selection command to show appropriate messages based on the current minigame's kit switching mode

### How to test?

1. Join a minigame with each of the different kit switching modes
2. Try selecting a different kit in each minigame and observe:
   - In `NEVER` mode: Kit selection is saved but not applied
   - In `ON_DEATH` mode: Kit changes after player dies and respawns
   - In `IMMEDIATE` mode: Kit changes immediately upon selection
3. Verify the appropriate message is displayed when selecting a kit in each mode
4. Test that kit switching works correctly during respawn countdown

### Why make this change?

This change provides more flexibility for minigame configuration by allowing different kit switching behaviors. Players now receive clearer feedback about when their kit selection will take effect, improving the user experience. The implementation also ensures kit switching works correctly in all scenarios, including during respawn countdown periods.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-minigame kit switching modes: Never, On Death, Immediate.
  * Immediate kit apply on selection when allowed; otherwise kit switches after respawn or remains unchanged.
  * Kit selection messages now indicate whether switching is immediate, on death, or disabled.
  * Respawn flow updated so selected kits are applied consistently according to the mode.

* **Chores**
  * Configuration updated to use kitSwitchingMode; prototyping minigame set to immediate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Related to #107 