### PR TITLE
Configure vercel backend deployment for elysia

### DIFF
--- a/api/[[...path]].ts
+++ b/api/[[...path]].ts
@@ -1,0 +1,68 @@
+import app from "../backend/dist/index.js";
+
+function getOriginalRequestUrl(req: any): string {
+  const proto = (req.headers["x-forwarded-proto"] as string) || "https";
+  const host =
+    (req.headers["x-forwarded-host"] as string) || req.headers.host || "localhost";
+  const currentUrl = new URL(req.url || "/", `${proto}://${host}`);
+
+  // Reconstruct the original path (strip the /api prefix added by Vercel routing)
+  let pathname = currentUrl.pathname || "/";
+  if (pathname === "/api") pathname = "/";
+  else if (pathname.startsWith("/api/")) pathname = pathname.slice(4) || "/";
+
+  const originalUrl = new URL(pathname + currentUrl.search, `${proto}://${host}`);
+  return originalUrl.toString();
+}
+
+function nodeHeadersToWebHeaders(nodeHeaders: Record<string, string | string[] | undefined>): Headers {
+  const headers = new Headers();
+  for (const [key, value] of Object.entries(nodeHeaders)) {
+    if (typeof value === "undefined") continue;
+    if (Array.isArray(value)) {
+      for (const v of value) headers.append(key, v);
+    } else {
+      headers.append(key, String(value));
+    }
+  }
+  return headers;
+}
+
+async function buildWebRequestFromNode(req: any): Promise<Request> {
+  const method = req.method || "GET";
+  const headers = nodeHeadersToWebHeaders(req.headers || {});
+  if (method === "GET" || method === "HEAD") {
+    return new Request(getOriginalRequestUrl(req), { method, headers });
+  }
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+  }
+  const body = Buffer.concat(chunks);
+  return new Request(getOriginalRequestUrl(req), { method, headers, body });
+}
+
+export default async function handler(req: any, res: any) {
+  try {
+    const request = await buildWebRequestFromNode(req);
+    const response = await app.handle(request);
+
+    res.statusCode = response.status;
+    response.headers.forEach((value, key) => {
+      res.setHeader(key, value);
+    });
+
+    if (!response.body) {
+      res.end();
+      return;
+    }
+
+    const buffer = Buffer.from(await response.arrayBuffer());
+    res.end(buffer);
+  } catch (error) {
+    console.error("Error in API handler:", error);
+    res.statusCode = 500;
+    res.end("Internal Server Error");
+  }
+}
+

--- a/api/[[...path]].ts
+++ b/api/[[...path]].ts
@@ -2,8 +2,7 @@ import app from "../backend/dist/index.js";
 
 function getOriginalRequestUrl(req: any): string {
   const proto = (req.headers["x-forwarded-proto"] as string) || "https";
-  const host =
-    (req.headers["x-forwarded-host"] as string) || req.headers.host || "localhost";
+  const host = (req.headers["x-forwarded-host"] as string) || req.headers.host || "localhost";
   const currentUrl = new URL(req.url || "/", `${proto}://${host}`);
 
   // Reconstruct the original path (strip the /api prefix added by Vercel routing)
@@ -15,7 +14,9 @@ function getOriginalRequestUrl(req: any): string {
   return originalUrl.toString();
 }
 
-function nodeHeadersToWebHeaders(nodeHeaders: Record<string, string | string[] | undefined>): Headers {
+function nodeHeadersToWebHeaders(
+  nodeHeaders: Record<string, string | string[] | undefined>,
+): Headers {
   const headers = new Headers();
   for (const [key, value] of Object.entries(nodeHeaders)) {
     if (typeof value === "undefined") continue;
@@ -65,4 +66,3 @@ export default async function handler(req: any, res: any) {
     res.end("Internal Server Error");
   }
 }
-

--- a/vercel.json
+++ b/vercel.json
@@ -1,23 +1,16 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "builds": [
-    {
-      "src": "backend/dist/index.js",
-      "use": "@vercel/node"
-    }
-  ],
   "routes": [
     {
       "src": "/(.*)",
-      "dest": "/backend/dist/index.js"
+      "dest": "/api/$1"
     }
   ],
   "functions": {
-    "backend/dist/index.js": {
+    "api/[[...path]].ts": {
       "runtime": "nodejs22.x"
     }
   },
-  "buildCommand": "bun run build",
-  "outputDirectory": "backend/dist",
+  "buildCommand": "bun run build:backend",
   "installCommand": "bun install"
 }


### PR DESCRIPTION
Configure Vercel to correctly run the Elysia backend app by routing all requests to a new serverless function instead of serving the built JS file statically.

The previous `vercel.json` configuration caused the built JavaScript file to be served as plain text. This PR introduces a catch-all serverless function (`api/[[...path]].ts`) that imports and executes the Elysia app, translating Node.js request/response objects to the Fetch API, and updates Vercel routing to direct all traffic to this function.

---
<a href="https://cursor.com/background-agent?bcId=bc-060faaeb-239f-4b59-8cd5-730a035f8c1f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-060faaeb-239f-4b59-8cd5-730a035f8c1f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

