### PR TITLE
Implement 1.8 pvp mechanics for mini games

### DIFF
--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/BrawlMinigame.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/BrawlMinigame.kt
@@ -47,6 +47,8 @@ import org.bukkit.event.entity.EntityDamageByEntityEvent
 import org.bukkit.event.entity.EntityDamageEvent
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.TimeSource
 
 abstract class BrawlMinigame<TMinigameDef : MinigameDef>(
     val minigameId: String,
@@ -71,9 +73,9 @@ abstract class BrawlMinigame<TMinigameDef : MinigameDef>(
 
     protected val assignedKits = mutableListOf<Pair<Player, BrawlKit>>()
 
-    /** 1.8-style invulnerability frames for melee (10 ticks = 500ms) */
-    private val meleeInvulnerabilityMs: Long = 500
-    private val lastMeleeHitAtByVictim = mutableMapOf<UUID, Long>()
+    /** 1.8-style melee I-frames (10 ticks) */
+    private val meleeIFrame = 500.milliseconds
+    private val lastMeleeHitAtByVictim = mutableMapOf<UUID, TimeSource.Monotonic.ValueTimeMark>()
 
     var state = MinigameState.PREFLIGHT
         protected set
@@ -150,17 +152,13 @@ abstract class BrawlMinigame<TMinigameDef : MinigameDef>(
                 }
 
                 // Trigger 1.8-style hurtcam/animation and sound on victim
-                try {
-                    victimPlayer.playEffect(EntityEffect.HURT)
-                } catch (_: Throwable) {}
-                try {
-                    victimPlayer.playSound(
-                        victimPlayer.eyeLocation,
-                        Sound.ENTITY_PLAYER_HURT,
-                        1f,
-                        1f,
-                    )
-                } catch (_: Throwable) {}
+                victimPlayer.playHurtAnimation(1f)
+                victimPlayer.playSound(
+                    victimPlayer.eyeLocation,
+                    Sound.ENTITY_PLAYER_HURT,
+                    1f,
+                    1f,
+                )
 
                 // Apply 1.8-style melee knockback only for melee damage (no special damage type)
                 if (damageType == null) {
@@ -179,8 +177,12 @@ abstract class BrawlMinigame<TMinigameDef : MinigameDef>(
                             null,
                         )
                         // Start 1.8-style melee invulnerability window
+                        if (victimPlayer.maximumNoDamageTicks != 10) {
+                            victimPlayer.maximumNoDamageTicks = 10
+                        }
                         victimPlayer.noDamageTicks = 10
-                        lastMeleeHitAtByVictim[victimPlayer.uniqueId] = System.currentTimeMillis()
+                        lastMeleeHitAtByVictim[victimPlayer.uniqueId] =
+                            TimeSource.Monotonic.markNow()
                     }
                 }
             }
@@ -209,10 +211,14 @@ abstract class BrawlMinigame<TMinigameDef : MinigameDef>(
                 isCancelled = true
 
                 // Enforce 1.8-style hit cooldown on victim (10 ticks)
-                val now = System.currentTimeMillis()
-                val lastHitAt = lastMeleeHitAtByVictim[victimPlayer.uniqueId]
-                if (lastHitAt != null && now - lastHitAt < meleeInvulnerabilityMs) {
+                if (victimPlayer.noDamageTicks > 0) {
                     return@event
+                }
+
+                lastMeleeHitAtByVictim[victimPlayer.uniqueId]?.let {
+                    if (it.elapsedNow() < meleeIFrame) {
+                        return@event
+                    }
                 }
 
                 val attackerKit = kitService.getKitForPlayer(damagerPlayer)
@@ -386,6 +392,7 @@ abstract class BrawlMinigame<TMinigameDef : MinigameDef>(
         }
         // Clean up respawning state if player leaves while respawning
         respawningPlayers.remove(player.uniqueId)
+        lastMeleeHitAtByVictim.remove(player.uniqueId)
     }
 
     /** Called when a player disconnects from the server while in this minigame */

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/BrawlMinigame.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/BrawlMinigame.kt
@@ -40,6 +40,7 @@ import kotlinx.coroutines.delay
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.title.Title
 import org.bukkit.GameMode
+import org.bukkit.EntityEffect
 import org.bukkit.Sound
 import org.bukkit.entity.Player
 import org.bukkit.event.entity.EntityDamageByEntityEvent
@@ -69,6 +70,10 @@ abstract class BrawlMinigame<TMinigameDef : MinigameDef>(
         protected set
 
     protected val assignedKits = mutableListOf<Pair<Player, BrawlKit>>()
+
+    /** 1.8-style invulnerability frames for melee (10 ticks = 500ms) */
+    private val meleeInvulnerabilityMs: Long = 500
+    private val lastMeleeHitAtByVictim = mutableMapOf<UUID, Long>()
 
     var state = MinigameState.PREFLIGHT
         protected set
@@ -144,6 +149,14 @@ abstract class BrawlMinigame<TMinigameDef : MinigameDef>(
                     victimPlayer.health = newHealth
                 }
 
+                // Trigger 1.8-style hurtcam/animation and sound on victim
+                try {
+                    victimPlayer.playEffect(EntityEffect.HURT)
+                } catch (_: Throwable) {}
+                try {
+                    victimPlayer.playSound(victimPlayer.eyeLocation, Sound.ENTITY_PLAYER_HURT, 1f, 1f)
+                } catch (_: Throwable) {}
+
                 // Apply 1.8-style melee knockback only for melee damage (no special damage type)
                 if (damageType == null) {
                     val damagerPlayer =
@@ -153,8 +166,6 @@ abstract class BrawlMinigame<TMinigameDef : MinigameDef>(
                             kitService.getKitForPlayer(damagerPlayer)?.let {
                                 dataService.getKit(it.id)?.knockbackMultiplier
                             } ?: 1.0
-
-                        victimPlayer.noDamageTicks = 0
                         victimPlayer.doKnockback(
                             knockbackMultiplier * kitKnockbackMult,
                             damage,
@@ -162,6 +173,9 @@ abstract class BrawlMinigame<TMinigameDef : MinigameDef>(
                             damagerPlayer.location.toVector(),
                             null,
                         )
+                        // Start 1.8-style melee invulnerability window
+                        victimPlayer.noDamageTicks = 10
+                        lastMeleeHitAtByVictim[victimPlayer.uniqueId] = System.currentTimeMillis()
                     }
                 }
             }
@@ -188,6 +202,13 @@ abstract class BrawlMinigame<TMinigameDef : MinigameDef>(
 
                 // Cancel vanilla damage and route through SmashDamageEvent using kit melee damage
                 isCancelled = true
+
+                // Enforce 1.8-style hit cooldown on victim (10 ticks)
+                val now = System.currentTimeMillis()
+                val lastHitAt = lastMeleeHitAtByVictim[victimPlayer.uniqueId]
+                if (lastHitAt != null && now - lastHitAt < meleeInvulnerabilityMs) {
+                    return@event
+                }
 
                 val attackerKit = kitService.getKitForPlayer(damagerPlayer)
                 val meleeDamage = attackerKit?.getMeleeDamage() ?: damage

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/BrawlMinigame.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/BrawlMinigame.kt
@@ -35,11 +35,12 @@ import gg.flyte.twilight.scheduler.repeatingTask
 import java.time.Duration
 import java.util.UUID
 import kotlin.math.min
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeSource
 import kotlinx.coroutines.delay
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.title.Title
-import org.bukkit.EntityEffect
 import org.bukkit.GameMode
 import org.bukkit.Sound
 import org.bukkit.entity.Player
@@ -47,8 +48,6 @@ import org.bukkit.event.entity.EntityDamageByEntityEvent
 import org.bukkit.event.entity.EntityDamageEvent
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
-import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.TimeSource
 
 abstract class BrawlMinigame<TMinigameDef : MinigameDef>(
     val minigameId: String,
@@ -153,12 +152,7 @@ abstract class BrawlMinigame<TMinigameDef : MinigameDef>(
 
                 // Trigger 1.8-style hurtcam/animation and sound on victim
                 victimPlayer.playHurtAnimation(1f)
-                victimPlayer.playSound(
-                    victimPlayer.eyeLocation,
-                    Sound.ENTITY_PLAYER_HURT,
-                    1f,
-                    1f,
-                )
+                victimPlayer.playSound(victimPlayer.eyeLocation, Sound.ENTITY_PLAYER_HURT, 1f, 1f)
 
                 // Apply 1.8-style melee knockback only for melee damage (no special damage type)
                 if (damageType == null) {

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/BrawlMinigame.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/BrawlMinigame.kt
@@ -39,8 +39,8 @@ import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.delay
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.title.Title
-import org.bukkit.GameMode
 import org.bukkit.EntityEffect
+import org.bukkit.GameMode
 import org.bukkit.Sound
 import org.bukkit.entity.Player
 import org.bukkit.event.entity.EntityDamageByEntityEvent
@@ -154,7 +154,12 @@ abstract class BrawlMinigame<TMinigameDef : MinigameDef>(
                     victimPlayer.playEffect(EntityEffect.HURT)
                 } catch (_: Throwable) {}
                 try {
-                    victimPlayer.playSound(victimPlayer.eyeLocation, Sound.ENTITY_PLAYER_HURT, 1f, 1f)
+                    victimPlayer.playSound(
+                        victimPlayer.eyeLocation,
+                        Sound.ENTITY_PLAYER_HURT,
+                        1f,
+                        1f,
+                    )
                 } catch (_: Throwable) {}
 
                 // Apply 1.8-style melee knockback only for melee damage (no special damage type)


### PR DESCRIPTION
Implement 1.8-style PvP mechanics in `BrawlMinigame` to precisely mimic classic Minecraft combat, including attack cooldown, hurtcam, knockback, and invulnerability frames.

---
<a href="https://cursor.com/background-agent?bcId=bc-19fd54a8-9e72-472d-8f40-f3a2f79e5277">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-19fd54a8-9e72-472d-8f40-f3a2f79e5277">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduces 1.8-style melee invulnerability (~0.5s / 10 ticks) for a classic combat feel.
  - Adds visible hurt animation and hit sound on damage for clearer feedback.

- **Bug Fixes**
  - Prevents unintended rapid consecutive melee hits by enforcing a brief cooldown between strikes on the same target.

- **Chores**
  - Cleans up cooldown tracking when players leave; public API/signatures unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->