### PR TITLE
Implement and migrate mini game managers

### DIFF
--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/BrawlMinigame.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/BrawlMinigame.kt
@@ -1,6 +1,22 @@
 package dev.betrix.superSmashMobsBrawl.minigames
 
 import dev.betrix.superSmashMobsBrawl.Manageable
+import dev.betrix.superSmashMobsBrawl.minigames.managers.DefaultCombatManager
+import dev.betrix.superSmashMobsBrawl.minigames.managers.DefaultCountdownManager
+import dev.betrix.superSmashMobsBrawl.minigames.managers.DefaultHazardManager
+import dev.betrix.superSmashMobsBrawl.minigames.managers.DefaultPlayerConnectionManager
+import dev.betrix.superSmashMobsBrawl.minigames.managers.DefaultRespawnManager
+import dev.betrix.superSmashMobsBrawl.minigames.managers.DefaultScoreboardManager
+import dev.betrix.superSmashMobsBrawl.minigames.managers.DefaultTeamManager
+import dev.betrix.superSmashMobsBrawl.minigames.managers.DefaultWorldManager
+import dev.betrix.superSmashMobsBrawl.minigames.managers.ICombatManager
+import dev.betrix.superSmashMobsBrawl.minigames.managers.ICountdownManager
+import dev.betrix.superSmashMobsBrawl.minigames.managers.IHazardManager
+import dev.betrix.superSmashMobsBrawl.minigames.managers.IPlayerConnectionManager
+import dev.betrix.superSmashMobsBrawl.minigames.managers.IRespawnManager
+import dev.betrix.superSmashMobsBrawl.minigames.managers.IScoreboardManager
+import dev.betrix.superSmashMobsBrawl.minigames.managers.ITeamManager
+import dev.betrix.superSmashMobsBrawl.minigames.managers.IWorldManager
 import dev.betrix.superSmashMobsBrawl.models.brawlData.KitDef
 import dev.betrix.superSmashMobsBrawl.models.brawlData.KitSwitchingMode
 import dev.betrix.superSmashMobsBrawl.models.brawlData.MinigameDef
@@ -9,25 +25,12 @@ import java.util.UUID
 import org.bukkit.OfflinePlayer
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
-import dev.betrix.superSmashMobsBrawl.minigames.managers.DefaultWorldManager
-import dev.betrix.superSmashMobsBrawl.minigames.managers.IWorldManager
-import dev.betrix.superSmashMobsBrawl.minigames.managers.DefaultTeamManager
-import dev.betrix.superSmashMobsBrawl.minigames.managers.ITeamManager
-import dev.betrix.superSmashMobsBrawl.minigames.managers.DefaultRespawnManager
-import dev.betrix.superSmashMobsBrawl.minigames.managers.IRespawnManager
-import dev.betrix.superSmashMobsBrawl.minigames.managers.DefaultCombatManager
-import dev.betrix.superSmashMobsBrawl.minigames.managers.ICombatManager
-import dev.betrix.superSmashMobsBrawl.minigames.managers.DefaultHazardManager
-import dev.betrix.superSmashMobsBrawl.minigames.managers.IHazardManager
-import dev.betrix.superSmashMobsBrawl.minigames.managers.DefaultCountdownManager
-import dev.betrix.superSmashMobsBrawl.minigames.managers.ICountdownManager
-import dev.betrix.superSmashMobsBrawl.minigames.managers.DefaultScoreboardManager
-import dev.betrix.superSmashMobsBrawl.minigames.managers.IScoreboardManager
-import dev.betrix.superSmashMobsBrawl.minigames.managers.DefaultPlayerConnectionManager
-import dev.betrix.superSmashMobsBrawl.minigames.managers.IPlayerConnectionManager
 
-
-data class MinigameTeam(val players: List<OfflinePlayer>, val id: String = UUID.randomUUID().toString(), val name: String) {
+data class MinigameTeam(
+    val players: List<OfflinePlayer>,
+    val id: String = UUID.randomUUID().toString(),
+    val name: String,
+) {
     init {
         require(players.isNotEmpty()) { "A team must have at least one player." }
     }
@@ -38,12 +41,14 @@ enum class MinigameState {
     STARTING,
     IN_PROGRESS,
     ENDING,
-    ENDED
+    ENDED,
 }
 
 interface ITeleportationHandler {
     fun teleportTeamToStartingLocation(team: MinigameTeam)
+
     fun teleportPlayerToSpectatorArea(player: OfflinePlayer)
+
     fun teleportPlayerRandomSpawnPoint(player: OfflinePlayer)
 }
 
@@ -63,19 +68,20 @@ class DefaultTeleportationHandler(private val minigame: BrawlMinigame) : ITelepo
 
 interface IKitHandler {
     fun assignKitToPlayer(player: OfflinePlayer)
+
     fun removeKitFromPlayer(player: OfflinePlayer)
 }
 
-/**
- * Default kit handler that keeps the player's kit unchanged throughout the game.
- */
-class DefaultKitHandler(private val minigame: BrawlMinigame): IKitHandler, KoinComponent {
+/** Default kit handler that keeps the player's kit unchanged throughout the game. */
+class DefaultKitHandler(private val minigame: BrawlMinigame) : IKitHandler, KoinComponent {
     private val kitService: KitService by inject()
 
     private val initialPlayerKits: Map<UUID, KitDef> =
         minigame.teams
             .flatMap { it.players }
-            .associate { player -> player.uniqueId to kitService.currentSelectedKitForPlayer(player) }
+            .associate { player ->
+                player.uniqueId to kitService.currentSelectedKitForPlayer(player)
+            }
             .toMap()
 
     override fun assignKitToPlayer(player: OfflinePlayer) {
@@ -87,25 +93,22 @@ class DefaultKitHandler(private val minigame: BrawlMinigame): IKitHandler, KoinC
     }
 }
 
-/**
- * Allows players to switch kits at anytime during the game
- */
-class KitHandlerWithSwitching(private val minigame: BrawlMinigame): IKitHandler, KoinComponent {
+/** Allows players to switch kits at anytime during the game */
+class KitHandlerWithSwitching(private val minigame: BrawlMinigame) : IKitHandler, KoinComponent {
     private val kitService: KitService by inject()
 
     override fun assignKitToPlayer(player: OfflinePlayer) {
-//        kitService.giveKitWithoutSwitching(player)
+        //        kitService.giveKitWithoutSwitching(player)
     }
 
     override fun removeKitFromPlayer(player: OfflinePlayer) {
-//        kitService.removeKit(player)
+        //        kitService.removeKit(player)
     }
 }
 
-/**
- * Allows players to switch kits, but only after they respawn from death
- */
-class KitHandlerWithSwitchingAfterDeath(private val minigame: BrawlMinigame): IKitHandler, KoinComponent {
+/** Allows players to switch kits, but only after they respawn from death */
+class KitHandlerWithSwitchingAfterDeath(private val minigame: BrawlMinigame) :
+    IKitHandler, KoinComponent {
     private val kitService: KitService by inject()
 
     override fun assignKitToPlayer(player: OfflinePlayer) {
@@ -113,13 +116,14 @@ class KitHandlerWithSwitchingAfterDeath(private val minigame: BrawlMinigame): IK
     }
 
     override fun removeKitFromPlayer(player: OfflinePlayer) {
-//        kitService.removeKit(player)
+        //        kitService.removeKit(player)
     }
 }
 
 interface ICombatHandler {}
 
-class BrawlMinigame(val minigameDef: MinigameDef, val teams: List<MinigameTeam>) : Manageable(), KoinComponent {
+class BrawlMinigame(val minigameDef: MinigameDef, val teams: List<MinigameTeam>) :
+    Manageable(), KoinComponent {
 
     private var state: MinigameState = MinigameState.PREFLIGHT
 
@@ -136,11 +140,12 @@ class BrawlMinigame(val minigameDef: MinigameDef, val teams: List<MinigameTeam>)
     val connectionManager: IPlayerConnectionManager = DefaultPlayerConnectionManager()
 
     // Kit handler is pluggable
-    private val kitHandler: IKitHandler = when (minigameDef.kitSwitchingMode) {
-        KitSwitchingMode.NEVER -> DefaultKitHandler(this)
-        KitSwitchingMode.ON_DEATH -> KitHandlerWithSwitchingAfterDeath(this)
-        KitSwitchingMode.IMMEDIATE -> KitHandlerWithSwitching(this)
-    }
+    private val kitHandler: IKitHandler =
+        when (minigameDef.kitSwitchingMode) {
+            KitSwitchingMode.NEVER -> DefaultKitHandler(this)
+            KitSwitchingMode.ON_DEATH -> KitHandlerWithSwitchingAfterDeath(this)
+            KitSwitchingMode.IMMEDIATE -> KitHandlerWithSwitching(this)
+        }
 
     fun allPlayers(): List<OfflinePlayer> = teams.flatMap { it.players }
 

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/BrawlMinigame.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/BrawlMinigame.kt
@@ -1,12 +1,30 @@
 package dev.betrix.superSmashMobsBrawl.minigames
 
+import dev.betrix.superSmashMobsBrawl.Manageable
 import dev.betrix.superSmashMobsBrawl.models.brawlData.KitDef
+import dev.betrix.superSmashMobsBrawl.models.brawlData.KitSwitchingMode
 import dev.betrix.superSmashMobsBrawl.models.brawlData.MinigameDef
 import dev.betrix.superSmashMobsBrawl.services.KitService
+import java.util.UUID
 import org.bukkit.OfflinePlayer
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
-import java.util.UUID
+import dev.betrix.superSmashMobsBrawl.minigames.managers.DefaultWorldManager
+import dev.betrix.superSmashMobsBrawl.minigames.managers.IWorldManager
+import dev.betrix.superSmashMobsBrawl.minigames.managers.DefaultTeamManager
+import dev.betrix.superSmashMobsBrawl.minigames.managers.ITeamManager
+import dev.betrix.superSmashMobsBrawl.minigames.managers.DefaultRespawnManager
+import dev.betrix.superSmashMobsBrawl.minigames.managers.IRespawnManager
+import dev.betrix.superSmashMobsBrawl.minigames.managers.DefaultCombatManager
+import dev.betrix.superSmashMobsBrawl.minigames.managers.ICombatManager
+import dev.betrix.superSmashMobsBrawl.minigames.managers.DefaultHazardManager
+import dev.betrix.superSmashMobsBrawl.minigames.managers.IHazardManager
+import dev.betrix.superSmashMobsBrawl.minigames.managers.DefaultCountdownManager
+import dev.betrix.superSmashMobsBrawl.minigames.managers.ICountdownManager
+import dev.betrix.superSmashMobsBrawl.minigames.managers.DefaultScoreboardManager
+import dev.betrix.superSmashMobsBrawl.minigames.managers.IScoreboardManager
+import dev.betrix.superSmashMobsBrawl.minigames.managers.DefaultPlayerConnectionManager
+import dev.betrix.superSmashMobsBrawl.minigames.managers.IPlayerConnectionManager
 
 
 data class MinigameTeam(val players: List<OfflinePlayer>, val id: String = UUID.randomUUID().toString(), val name: String) {
@@ -101,11 +119,53 @@ class KitHandlerWithSwitchingAfterDeath(private val minigame: BrawlMinigame): IK
 
 interface ICombatHandler {}
 
-class BrawlMinigame(val minigameDef: MinigameDef, val teams: List<MinigameTeam>) {
+class BrawlMinigame(val minigameDef: MinigameDef, val teams: List<MinigameTeam>) : Manageable(), KoinComponent {
 
     private var state: MinigameState = MinigameState.PREFLIGHT
 
     private val teleportationHandler: ITeleportationHandler = DefaultTeleportationHandler(this)
 
-    init {}
+    // Managers (composable)
+    val worldManager: IWorldManager = DefaultWorldManager()
+    val teamManager: ITeamManager = DefaultTeamManager()
+    val respawnManager: IRespawnManager = DefaultRespawnManager(this)
+    val combatManager: ICombatManager = DefaultCombatManager()
+    val hazardManager: IHazardManager = DefaultHazardManager()
+    val countdownManager: ICountdownManager = DefaultCountdownManager(this)
+    val scoreboardManager: IScoreboardManager = DefaultScoreboardManager()
+    val connectionManager: IPlayerConnectionManager = DefaultPlayerConnectionManager()
+
+    // Kit handler is pluggable
+    private val kitHandler: IKitHandler = when (minigameDef.kitSwitchingMode) {
+        KitSwitchingMode.NEVER -> DefaultKitHandler(this)
+        KitSwitchingMode.ON_DEATH -> KitHandlerWithSwitchingAfterDeath(this)
+        KitSwitchingMode.IMMEDIATE -> KitHandlerWithSwitching(this)
+    }
+
+    fun allPlayers(): List<OfflinePlayer> = teams.flatMap { it.players }
+
+    fun getKitSwitchingMode(): KitSwitchingMode = minigameDef.kitSwitchingMode
+
+    fun isPassiveValid(id: String): Boolean = minigameDef.isPassiveValid(id)
+
+    suspend fun setup(gameId: String) {
+        // Load world
+        worldManager.loadWorld(minigameDef, gameId)
+        // Teams
+        teamManager.registerTeams(this)
+        // Hazards and combat
+        hazardManager.initialize(this)
+        combatManager.initialize(this)
+        // Scoreboard init
+        scoreboardManager.initialize()
+        state = MinigameState.STARTING
+    }
+
+    override fun teardown() {
+        super.teardown()
+        hazardManager.teardown()
+        combatManager.teardown()
+        scoreboardManager.teardown()
+        (worldManager as? Manageable)?.teardown()
+    }
 }

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/managers/CombatManager.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/managers/CombatManager.kt
@@ -1,0 +1,16 @@
+package dev.betrix.superSmashMobsBrawl.minigames.managers
+
+import dev.betrix.superSmashMobsBrawl.Manageable
+import dev.betrix.superSmashMobsBrawl.minigames.BrawlMinigame
+import org.bukkit.event.Listener
+
+interface ICombatManager : Listener {
+    fun initialize(minigame: BrawlMinigame)
+}
+
+class DefaultCombatManager : Manageable(), ICombatManager {
+    override fun initialize(minigame: BrawlMinigame) {
+        // Register damage listeners in future
+    }
+}
+

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/managers/CombatManager.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/managers/CombatManager.kt
@@ -13,4 +13,3 @@ class DefaultCombatManager : Manageable(), ICombatManager {
         // Register damage listeners in future
     }
 }
-

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/managers/CountdownManager.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/managers/CountdownManager.kt
@@ -7,9 +7,13 @@ interface ICountdownManager {
     fun startCountdown(seconds: Int, onTick: (secondsLeft: Int) -> Unit, onComplete: () -> Unit)
 }
 
-class DefaultCountdownManager(private val minigame: BrawlMinigame) : Manageable(), ICountdownManager {
-    override fun startCountdown(seconds: Int, onTick: (secondsLeft: Int) -> Unit, onComplete: () -> Unit) {
+class DefaultCountdownManager(private val minigame: BrawlMinigame) :
+    Manageable(), ICountdownManager {
+    override fun startCountdown(
+        seconds: Int,
+        onTick: (secondsLeft: Int) -> Unit,
+        onComplete: () -> Unit,
+    ) {
         // Skeleton; will use scheduler later
     }
 }
-

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/managers/CountdownManager.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/managers/CountdownManager.kt
@@ -1,0 +1,15 @@
+package dev.betrix.superSmashMobsBrawl.minigames.managers
+
+import dev.betrix.superSmashMobsBrawl.Manageable
+import dev.betrix.superSmashMobsBrawl.minigames.BrawlMinigame
+
+interface ICountdownManager {
+    fun startCountdown(seconds: Int, onTick: (secondsLeft: Int) -> Unit, onComplete: () -> Unit)
+}
+
+class DefaultCountdownManager(private val minigame: BrawlMinigame) : Manageable(), ICountdownManager {
+    override fun startCountdown(seconds: Int, onTick: (secondsLeft: Int) -> Unit, onComplete: () -> Unit) {
+        // Skeleton; will use scheduler later
+    }
+}
+

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/managers/GameObjectiveManager.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/managers/GameObjectiveManager.kt
@@ -6,12 +6,15 @@ import org.bukkit.OfflinePlayer
 
 sealed class WinResult {
     object None : WinResult()
+
     data class Winners(val winners: List<OfflinePlayer>) : WinResult()
 }
 
 interface IGameObjectiveManager {
     fun initialize(minigame: BrawlMinigame)
+
     fun recordDeath(player: OfflinePlayer)
+
     fun checkWinCondition(): WinResult
 }
 
@@ -22,4 +25,3 @@ class DefaultGameObjectiveManager : Manageable(), IGameObjectiveManager {
 
     override fun checkWinCondition(): WinResult = WinResult.None
 }
-

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/managers/GameObjectiveManager.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/managers/GameObjectiveManager.kt
@@ -1,0 +1,25 @@
+package dev.betrix.superSmashMobsBrawl.minigames.managers
+
+import dev.betrix.superSmashMobsBrawl.Manageable
+import dev.betrix.superSmashMobsBrawl.minigames.BrawlMinigame
+import org.bukkit.OfflinePlayer
+
+sealed class WinResult {
+    object None : WinResult()
+    data class Winners(val winners: List<OfflinePlayer>) : WinResult()
+}
+
+interface IGameObjectiveManager {
+    fun initialize(minigame: BrawlMinigame)
+    fun recordDeath(player: OfflinePlayer)
+    fun checkWinCondition(): WinResult
+}
+
+class DefaultGameObjectiveManager : Manageable(), IGameObjectiveManager {
+    override fun initialize(minigame: BrawlMinigame) {}
+
+    override fun recordDeath(player: OfflinePlayer) {}
+
+    override fun checkWinCondition(): WinResult = WinResult.None
+}
+

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/managers/HazardManager.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/managers/HazardManager.kt
@@ -3,7 +3,6 @@ package dev.betrix.superSmashMobsBrawl.minigames.managers
 import dev.betrix.superSmashMobsBrawl.Manageable
 import dev.betrix.superSmashMobsBrawl.events.BrawlDeathEvent
 import dev.betrix.superSmashMobsBrawl.events.DeathReason
-import dev.betrix.superSmashMobsBrawl.extensions.teleport
 import dev.betrix.superSmashMobsBrawl.minigames.BrawlMinigame
 import gg.flyte.twilight.scheduler.repeatingTask
 import org.bukkit.GameMode
@@ -30,4 +29,3 @@ class DefaultHazardManager : Manageable(), IHazardManager {
         )
     }
 }
-

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/managers/HazardManager.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/managers/HazardManager.kt
@@ -1,0 +1,33 @@
+package dev.betrix.superSmashMobsBrawl.minigames.managers
+
+import dev.betrix.superSmashMobsBrawl.Manageable
+import dev.betrix.superSmashMobsBrawl.events.BrawlDeathEvent
+import dev.betrix.superSmashMobsBrawl.events.DeathReason
+import dev.betrix.superSmashMobsBrawl.extensions.teleport
+import dev.betrix.superSmashMobsBrawl.minigames.BrawlMinigame
+import gg.flyte.twilight.scheduler.repeatingTask
+import org.bukkit.GameMode
+
+interface IHazardManager {
+    fun initialize(minigame: BrawlMinigame)
+}
+
+class DefaultHazardManager : Manageable(), IHazardManager {
+    override fun initialize(minigame: BrawlMinigame) {
+        val world = minigame.worldManager.getWorld() ?: return
+        val voidLevel = world.data.voidLevel
+
+        runnables.add(
+            repeatingTask(5) {
+                minigame.allPlayers().forEach { p ->
+                    if (p.isOnline && p.player!!.gameMode == GameMode.SURVIVAL) {
+                        if (p.player!!.location.y <= voidLevel) {
+                            BrawlDeathEvent.call(p.player!!, DeathReason.Void)
+                        }
+                    }
+                }
+            }
+        )
+    }
+}
+

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/managers/PlayerConnectionManager.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/managers/PlayerConnectionManager.kt
@@ -5,7 +5,9 @@ import org.bukkit.OfflinePlayer
 
 interface IPlayerConnectionManager {
     fun markDisconnected(player: OfflinePlayer)
+
     fun markReconnected(player: OfflinePlayer)
+
     fun isDisconnected(player: OfflinePlayer): Boolean
 }
 
@@ -20,6 +22,6 @@ class DefaultPlayerConnectionManager : Manageable(), IPlayerConnectionManager {
         disconnected.remove(player.uniqueId)
     }
 
-    override fun isDisconnected(player: OfflinePlayer): Boolean = disconnected.contains(player.uniqueId)
+    override fun isDisconnected(player: OfflinePlayer): Boolean =
+        disconnected.contains(player.uniqueId)
 }
-

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/managers/PlayerConnectionManager.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/managers/PlayerConnectionManager.kt
@@ -1,0 +1,25 @@
+package dev.betrix.superSmashMobsBrawl.minigames.managers
+
+import dev.betrix.superSmashMobsBrawl.Manageable
+import org.bukkit.OfflinePlayer
+
+interface IPlayerConnectionManager {
+    fun markDisconnected(player: OfflinePlayer)
+    fun markReconnected(player: OfflinePlayer)
+    fun isDisconnected(player: OfflinePlayer): Boolean
+}
+
+class DefaultPlayerConnectionManager : Manageable(), IPlayerConnectionManager {
+    private val disconnected = mutableSetOf<java.util.UUID>()
+
+    override fun markDisconnected(player: OfflinePlayer) {
+        disconnected.add(player.uniqueId)
+    }
+
+    override fun markReconnected(player: OfflinePlayer) {
+        disconnected.remove(player.uniqueId)
+    }
+
+    override fun isDisconnected(player: OfflinePlayer): Boolean = disconnected.contains(player.uniqueId)
+}
+

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/managers/RespawnManager.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/managers/RespawnManager.kt
@@ -1,0 +1,28 @@
+package dev.betrix.superSmashMobsBrawl.minigames.managers
+
+import dev.betrix.superSmashMobsBrawl.Manageable
+import dev.betrix.superSmashMobsBrawl.minigames.BrawlMinigame
+import org.bukkit.OfflinePlayer
+
+interface IRespawnManager {
+    fun markRespawning(player: OfflinePlayer)
+    fun clearRespawning(player: OfflinePlayer)
+    fun isRespawning(player: OfflinePlayer): Boolean
+}
+
+class DefaultRespawnManager(private val minigame: BrawlMinigame) : Manageable(), IRespawnManager {
+    private val respawning = mutableSetOf<java.util.UUID>()
+
+    override fun markRespawning(player: OfflinePlayer) {
+        respawning.add(player.uniqueId)
+    }
+
+    override fun clearRespawning(player: OfflinePlayer) {
+        respawning.remove(player.uniqueId)
+    }
+
+    override fun isRespawning(player: OfflinePlayer): Boolean {
+        return respawning.contains(player.uniqueId)
+    }
+}
+

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/managers/RespawnManager.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/managers/RespawnManager.kt
@@ -6,7 +6,9 @@ import org.bukkit.OfflinePlayer
 
 interface IRespawnManager {
     fun markRespawning(player: OfflinePlayer)
+
     fun clearRespawning(player: OfflinePlayer)
+
     fun isRespawning(player: OfflinePlayer): Boolean
 }
 
@@ -25,4 +27,3 @@ class DefaultRespawnManager(private val minigame: BrawlMinigame) : Manageable(),
         return respawning.contains(player.uniqueId)
     }
 }
-

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/managers/ScoreboardManager.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/managers/ScoreboardManager.kt
@@ -5,13 +5,18 @@ import org.bukkit.OfflinePlayer
 
 interface IScoreboardManager {
     fun initialize()
+
     fun updateForPlayer(player: OfflinePlayer)
+
     fun teardown()
 }
 
 class DefaultScoreboardManager : Manageable(), IScoreboardManager {
     override fun initialize() {}
-    override fun updateForPlayer(player: OfflinePlayer) {}
-    override fun teardown() { super.teardown() }
-}
 
+    override fun updateForPlayer(player: OfflinePlayer) {}
+
+    override fun teardown() {
+        super.teardown()
+    }
+}

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/managers/ScoreboardManager.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/managers/ScoreboardManager.kt
@@ -1,0 +1,17 @@
+package dev.betrix.superSmashMobsBrawl.minigames.managers
+
+import dev.betrix.superSmashMobsBrawl.Manageable
+import org.bukkit.OfflinePlayer
+
+interface IScoreboardManager {
+    fun initialize()
+    fun updateForPlayer(player: OfflinePlayer)
+    fun teardown()
+}
+
+class DefaultScoreboardManager : Manageable(), IScoreboardManager {
+    override fun initialize() {}
+    override fun updateForPlayer(player: OfflinePlayer) {}
+    override fun teardown() { super.teardown() }
+}
+

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/managers/SpectatorManager.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/managers/SpectatorManager.kt
@@ -6,6 +6,7 @@ import org.bukkit.OfflinePlayer
 
 interface ISpectatorManager {
     fun setSpectator(player: OfflinePlayer)
+
     fun clearSpectator(player: OfflinePlayer)
 }
 
@@ -27,4 +28,3 @@ class DefaultSpectatorManager : Manageable(), ISpectatorManager {
         }
     }
 }
-

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/managers/SpectatorManager.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/managers/SpectatorManager.kt
@@ -1,0 +1,30 @@
+package dev.betrix.superSmashMobsBrawl.minigames.managers
+
+import dev.betrix.superSmashMobsBrawl.Manageable
+import org.bukkit.GameMode
+import org.bukkit.OfflinePlayer
+
+interface ISpectatorManager {
+    fun setSpectator(player: OfflinePlayer)
+    fun clearSpectator(player: OfflinePlayer)
+}
+
+class DefaultSpectatorManager : Manageable(), ISpectatorManager {
+    override fun setSpectator(player: OfflinePlayer) {
+        if (player.isOnline) {
+            val bukkit = player.player!!
+            bukkit.gameMode = GameMode.SPECTATOR
+            bukkit.allowFlight = true
+            bukkit.isFlying = true
+            bukkit.fallDistance = 0f
+        }
+    }
+
+    override fun clearSpectator(player: OfflinePlayer) {
+        if (player.isOnline) {
+            val bukkit = player.player!!
+            bukkit.gameMode = GameMode.SURVIVAL
+        }
+    }
+}
+

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/managers/TeamManager.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/managers/TeamManager.kt
@@ -1,0 +1,31 @@
+package dev.betrix.superSmashMobsBrawl.minigames.managers
+
+import dev.betrix.superSmashMobsBrawl.Manageable
+import dev.betrix.superSmashMobsBrawl.minigames.BrawlMinigame
+import org.bukkit.OfflinePlayer
+
+interface ITeamManager {
+    fun registerTeams(minigame: BrawlMinigame)
+    fun findTeamOf(player: OfflinePlayer): dev.betrix.superSmashMobsBrawl.minigames.MinigameTeam?
+    fun getTeams(): List<dev.betrix.superSmashMobsBrawl.minigames.MinigameTeam>
+    fun onPlayerLeave(player: OfflinePlayer) {}
+}
+
+class DefaultTeamManager : Manageable(), ITeamManager {
+    private val playerToTeam = mutableMapOf<java.util.UUID, dev.betrix.superSmashMobsBrawl.minigames.MinigameTeam>()
+    private var teams: List<dev.betrix.superSmashMobsBrawl.minigames.MinigameTeam> = emptyList()
+
+    override fun registerTeams(minigame: BrawlMinigame) {
+        teams = minigame.teams
+        teams.forEach { team ->
+            team.players.forEach { p -> playerToTeam[p.uniqueId] = team }
+        }
+    }
+
+    override fun findTeamOf(player: OfflinePlayer): dev.betrix.superSmashMobsBrawl.minigames.MinigameTeam? {
+        return playerToTeam[player.uniqueId]
+    }
+
+    override fun getTeams(): List<dev.betrix.superSmashMobsBrawl.minigames.MinigameTeam> = teams
+}
+

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/managers/TeamManager.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/managers/TeamManager.kt
@@ -6,26 +6,29 @@ import org.bukkit.OfflinePlayer
 
 interface ITeamManager {
     fun registerTeams(minigame: BrawlMinigame)
+
     fun findTeamOf(player: OfflinePlayer): dev.betrix.superSmashMobsBrawl.minigames.MinigameTeam?
+
     fun getTeams(): List<dev.betrix.superSmashMobsBrawl.minigames.MinigameTeam>
+
     fun onPlayerLeave(player: OfflinePlayer) {}
 }
 
 class DefaultTeamManager : Manageable(), ITeamManager {
-    private val playerToTeam = mutableMapOf<java.util.UUID, dev.betrix.superSmashMobsBrawl.minigames.MinigameTeam>()
+    private val playerToTeam =
+        mutableMapOf<java.util.UUID, dev.betrix.superSmashMobsBrawl.minigames.MinigameTeam>()
     private var teams: List<dev.betrix.superSmashMobsBrawl.minigames.MinigameTeam> = emptyList()
 
     override fun registerTeams(minigame: BrawlMinigame) {
         teams = minigame.teams
-        teams.forEach { team ->
-            team.players.forEach { p -> playerToTeam[p.uniqueId] = team }
-        }
+        teams.forEach { team -> team.players.forEach { p -> playerToTeam[p.uniqueId] = team } }
     }
 
-    override fun findTeamOf(player: OfflinePlayer): dev.betrix.superSmashMobsBrawl.minigames.MinigameTeam? {
+    override fun findTeamOf(
+        player: OfflinePlayer
+    ): dev.betrix.superSmashMobsBrawl.minigames.MinigameTeam? {
         return playerToTeam[player.uniqueId]
     }
 
     override fun getTeams(): List<dev.betrix.superSmashMobsBrawl.minigames.MinigameTeam> = teams
 }
-

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/managers/WorldManager.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/managers/WorldManager.kt
@@ -10,12 +10,15 @@ import dev.betrix.superSmashMobsBrawl.services.WorldService
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
-/**
- * Responsible for selecting, loading, and cleaning up the game world for a minigame.
- */
+/** Responsible for selecting, loading, and cleaning up the game world for a minigame. */
 interface IWorldManager {
-    suspend fun loadWorld(minigameDef: MinigameDef, gameId: String): Result<BrawlGameWorld, Exception>
+    suspend fun loadWorld(
+        minigameDef: MinigameDef,
+        gameId: String,
+    ): Result<BrawlGameWorld, Exception>
+
     fun getWorld(): BrawlGameWorld?
+
     fun teardown()
 }
 
@@ -40,12 +43,13 @@ class DefaultWorldManager : Manageable(), IWorldManager, KoinComponent {
                 true
             }
 
-        val selectedMap = validMaps.randomOrNull() ?: return com.github.michaelbull.result.Err(
-            RuntimeException("No valid maps found for ${minigameDef.id}")
-        )
+        val selectedMap =
+            validMaps.randomOrNull()
+                ?: return com.github.michaelbull.result.Err(
+                    RuntimeException("No valid maps found for ${minigameDef.id}")
+                )
 
-        val result =
-            worldService.copyAndLoadWorld(selectedMap, gameId).map { it as BrawlGameWorld }
+        val result = worldService.copyAndLoadWorld(selectedMap, gameId).map { it as BrawlGameWorld }
         result.map { loaded -> brawlWorld = loaded }
         return result
     }
@@ -58,4 +62,3 @@ class DefaultWorldManager : Manageable(), IWorldManager, KoinComponent {
         brawlWorld = null
     }
 }
-

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/managers/WorldManager.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/managers/WorldManager.kt
@@ -1,0 +1,61 @@
+package dev.betrix.superSmashMobsBrawl.minigames.managers
+
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.map
+import dev.betrix.superSmashMobsBrawl.Manageable
+import dev.betrix.superSmashMobsBrawl.models.BrawlGameWorld
+import dev.betrix.superSmashMobsBrawl.models.brawlData.MinigameDef
+import dev.betrix.superSmashMobsBrawl.services.DataService
+import dev.betrix.superSmashMobsBrawl.services.WorldService
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
+/**
+ * Responsible for selecting, loading, and cleaning up the game world for a minigame.
+ */
+interface IWorldManager {
+    suspend fun loadWorld(minigameDef: MinigameDef, gameId: String): Result<BrawlGameWorld, Exception>
+    fun getWorld(): BrawlGameWorld?
+    fun teardown()
+}
+
+class DefaultWorldManager : Manageable(), IWorldManager, KoinComponent {
+    private val worldService: WorldService by inject()
+    private val dataService: DataService by inject()
+
+    private var brawlWorld: BrawlGameWorld? = null
+
+    override suspend fun loadWorld(
+        minigameDef: MinigameDef,
+        gameId: String,
+    ): Result<BrawlGameWorld, Exception> {
+        val validMaps =
+            dataService.getAllGameMaps().filter { map ->
+                minigameDef.mapWhitelist?.let { whitelist ->
+                    return@filter whitelist.contains(map.id)
+                }
+                minigameDef.mapBlacklist?.let { blacklist ->
+                    return@filter !blacklist.contains(map.id)
+                }
+                true
+            }
+
+        val selectedMap = validMaps.randomOrNull() ?: return com.github.michaelbull.result.Err(
+            RuntimeException("No valid maps found for ${minigameDef.id}")
+        )
+
+        val result =
+            worldService.copyAndLoadWorld(selectedMap, gameId).map { it as BrawlGameWorld }
+        result.map { loaded -> brawlWorld = loaded }
+        return result
+    }
+
+    override fun getWorld(): BrawlGameWorld? = brawlWorld
+
+    override fun teardown() {
+        super.teardown()
+        // WorldService handles unloading via its own lifecycle; nothing to do here yet.
+        brawlWorld = null
+    }
+}
+

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/KitService.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/services/KitService.kt
@@ -1,6 +1,5 @@
 package dev.betrix.superSmashMobsBrawl.services
 
-import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.shynixn.mccoroutine.bukkit.launch


### PR DESCRIPTION
Introduce the manager pattern to `BrawlMinigame` for composable mini-game instances and migrate initial features.

---
<a href="https://cursor.com/background-agent?bcId=bc-a793ad41-70fe-4706-b523-425fc5f7df60">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a793ad41-70fe-4706-b523-425fc5f7df60">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

