### PR TITLE
add custom melee reach for kits

### DIFF
--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/kits/BrawlKit.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/kits/BrawlKit.kt
@@ -23,7 +23,7 @@ open class BrawlKit(val id: String, val player: Player) : KoinComponent {
     private val logger: Logger by inject()
 
     protected val minigameInstance = minigameService.getMinigameForPlayer(player)
-    val kitData =
+    protected val kitData =
         dataService.getKit(id) ?: throw RuntimeException("No kit found in DataService with id $id")
 
     protected val abilities = arrayListOf<BrawlAbility>()
@@ -32,6 +32,8 @@ open class BrawlKit(val id: String, val player: Player) : KoinComponent {
     protected var disguise: BrawlDisguise? = null
 
     fun getMeleeDamage(): Double = kitData.meleeDamage
+    fun getMeleeReach(): Double = kitData.meleeReach
+    fun getKnockbackMultiplier(): Double = kitData.knockbackMultiplier
 
     fun getPassive(id: String): BrawlPassive? {
         return passives.find { it.id == id }

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/kits/BrawlKit.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/kits/BrawlKit.kt
@@ -23,7 +23,7 @@ open class BrawlKit(val id: String, val player: Player) : KoinComponent {
     private val logger: Logger by inject()
 
     protected val minigameInstance = minigameService.getMinigameForPlayer(player)
-    protected val kitData =
+    val kitData =
         dataService.getKit(id) ?: throw RuntimeException("No kit found in DataService with id $id")
 
     protected val abilities = arrayListOf<BrawlAbility>()

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/BrawlMinigame.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/BrawlMinigame.kt
@@ -344,6 +344,15 @@ class BrawlMinigame(val minigameDef: MinigameDef, val teams: List<MinigameTeam>)
         teardown()
     }
 
+    fun arePlayersOnSameTeam(playerA: OfflinePlayer, playerB: OfflinePlayer): Boolean {
+        val teamA = teamManager.findTeamOf(playerA)
+        val teamB = teamManager.findTeamOf(playerB)
+
+        if (teamA == null || teamB == null) return false
+
+        return teamA.id == teamB.id
+    }
+
     override fun teardown() {
         super.teardown()
         (hazardManager as? Manageable)?.teardown()

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/managers/CombatManager.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/managers/CombatManager.kt
@@ -8,6 +8,8 @@ import dev.betrix.superSmashMobsBrawl.events.Damager
 import dev.betrix.superSmashMobsBrawl.events.DeathReason
 import dev.betrix.superSmashMobsBrawl.events.PlayerDamageAnalyticsEvent
 import dev.betrix.superSmashMobsBrawl.events.BrawlDamageEvent
+import dev.betrix.superSmashMobsBrawl.events.BrawlDamageType
+import dev.betrix.superSmashMobsBrawl.extensions.disguise
 import dev.betrix.superSmashMobsBrawl.extensions.doKnockback
 import dev.betrix.superSmashMobsBrawl.minigames.BrawlMinigame
 import dev.betrix.superSmashMobsBrawl.services.DataService
@@ -17,11 +19,16 @@ import java.util.UUID
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.TimeSource
 import org.bukkit.GameMode
+import org.bukkit.OfflinePlayer
 import org.bukkit.Sound
 import org.bukkit.entity.Player
 import org.bukkit.event.Listener
+import org.bukkit.event.block.Action
 import org.bukkit.event.entity.EntityDamageByEntityEvent
 import org.bukkit.event.entity.EntityDamageEvent
+import org.bukkit.event.player.PlayerInteractEvent
+import org.bukkit.util.BoundingBox
+import org.bukkit.util.Vector
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
@@ -38,6 +45,60 @@ class DefaultCombatManager(private val minigame: BrawlMinigame) :
     private val lastMeleeHitAtByVictim = mutableMapOf<UUID, TimeSource.Monotonic.ValueTimeMark>()
 
     override fun setup() {
+        listeners.add(
+            event<PlayerInteractEvent> {
+                if (action != Action.LEFT_CLICK_AIR || !isPlayerInMinigame(player)) {
+                    return@event
+                }
+
+                val playerKit = kitService.getKitForPlayer(player) ?: return@event
+
+                val playerMeleeReach = playerKit.kitData.meleeReach
+                val playerMeleeDamage = playerKit.kitData.meleeDamage
+
+                player.world.livingEntities.filter { entity ->
+                    if (entity == player) {
+                        return@filter false
+                    }
+
+                    // Players on same team should not be targetable
+                    if (entity is OfflinePlayer && minigame.arePlayersOnSameTeam(player, entity)) {
+                        return@filter false
+                    }
+
+                    val candidateBox = (entity as? Player)?.disguise?.boundingBox ?: entity.boundingBox
+
+                    return@filter isEntityInMeleeReach(player, candidateBox, playerMeleeReach)
+                }.minByOrNull {
+                    it.location.distance(player.location)
+                }?.let {
+                    BrawlDamageEvent(
+                        it,
+                        Damager.DamagerLivingEntity(player),
+                        playerMeleeDamage,
+                        damageType = BrawlDamageType.MeleeAttack
+                    ).callEvent()
+                }
+            }
+        )
+
+        listeners.add(
+            event<EntityDamageByEntityEvent> {
+                if (isCancelled) return@event
+
+                val victimPlayer = entity as? Player ?: return@event
+
+                if (!isPlayerInMinigame(victimPlayer)) return@event
+
+                // Cancel all non-melee damage within this minigame - handled by BrawlDamageEvent
+                if (
+                    cause != EntityDamageEvent.DamageCause.ENTITY_ATTACK &&
+                        cause != EntityDamageEvent.DamageCause.ENTITY_SWEEP_ATTACK
+                ) {
+                    isCancelled = true
+                }
+            }
+        )
 
         // Handle SmashDamageEvent - apply damage within the context of this minigame
         listeners.add(
@@ -46,6 +107,13 @@ class DefaultCombatManager(private val minigame: BrawlMinigame) :
                 if (!isPlayerInMinigame(victim as? Player)) return@event
 
                 val victimPlayer = victim as? Player ?: return@event
+
+                // Don't let players on same team damage each other
+                ((damager as? Damager.DamagerLivingEntity)?.livingEntity as? Player)?.let {
+                    if (minigame.arePlayersOnSameTeam(it, victimPlayer)) {
+                        return@event
+                    }
+                }
 
                 if (victimPlayer.gameMode != GameMode.SURVIVAL) return@event
 
@@ -87,9 +155,7 @@ class DefaultCombatManager(private val minigame: BrawlMinigame) :
                         (damager as? Damager.DamagerLivingEntity)?.livingEntity as? Player
                     if (damagerPlayer != null) {
                         val kitKnockbackMult =
-                            kitService.getKitForPlayer(damagerPlayer)?.let {
-                                dataService.getKit(it.id)?.knockbackMultiplier
-                            } ?: 1.0
+                            kitService.getKitForPlayer(damagerPlayer)?.kitData?.knockbackMultiplier ?: 1.0
                         victimPlayer.doKnockback(
                             knockbackMultiplier * kitKnockbackMult,
                             damage,
@@ -164,5 +230,76 @@ class DefaultCombatManager(private val minigame: BrawlMinigame) :
     override fun teardown() {
         super.teardown()
         lastMeleeHitAtByVictim.clear()
+    }
+
+    private fun isEntityInMeleeReach(
+        player: Player,
+        boundingBox: BoundingBox,
+        meleeReach: Double
+    ): Boolean {
+        val eyeLocation = player.eyeLocation
+        val direction = eyeLocation.direction
+
+        // Cast ray from player's eye location in their looking direction
+        val rayStart = eyeLocation.toVector()
+
+        // Check intersection with bounding box
+        val intersection = rayIntersectsBoundingBox(rayStart, direction, boundingBox)
+
+        return intersection != null && intersection.distance(rayStart) <= meleeReach
+    }
+
+    private fun rayIntersectsBoundingBox(
+        rayStart: Vector,
+        rayDirection: Vector,
+        boundingBox: BoundingBox
+    ): Vector? {
+        val min = Vector(boundingBox.minX, boundingBox.minY, boundingBox.minZ)
+        val max = Vector(boundingBox.maxX, boundingBox.maxY, boundingBox.maxZ)
+
+        var tMin = (min.x - rayStart.x) / rayDirection.x
+        var tMax = (max.x - rayStart.x) / rayDirection.x
+
+        if (tMin > tMax) {
+            val temp = tMin
+            tMin = tMax
+            tMax = temp
+        }
+
+        var tyMin = (min.y - rayStart.y) / rayDirection.y
+        var tyMax = (max.y - rayStart.y) / rayDirection.y
+
+        if (tyMin > tyMax) {
+            val temp = tyMin
+            tyMin = tyMax
+            tyMax = temp
+        }
+
+        if (tMin > tyMax || tyMin > tMax) {
+            return null
+        }
+
+        if (tyMin > tMin) tMin = tyMin
+        if (tyMax < tMax) tMax = tyMax
+
+        var tzMin = (min.z - rayStart.z) / rayDirection.z
+        var tzMax = (max.z - rayStart.z) / rayDirection.z
+
+        if (tzMin > tzMax) {
+            val temp = tzMin
+            tzMin = tzMax
+            tzMax = temp
+        }
+
+        if (tMin > tzMax || tzMin > tMax) {
+            return null
+        }
+
+        if (tzMin > tMin) tMin = tzMin
+
+        // Return intersection point
+        return if (tMin >= 0) {
+            rayStart.clone().add(rayDirection.clone().multiply(tMin))
+        } else null
     }
 }

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/managers/CombatManager.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/managers/CombatManager.kt
@@ -37,8 +37,6 @@ interface ICombatManager : Listener, IManageable {}
 class DefaultCombatManager(private val minigame: BrawlMinigame) :
     Manageable(), ICombatManager, KoinComponent {
     private val kitService: KitService by inject()
-    private val dataService: DataService by inject()
-    private val plugin: SuperSmashMobsBrawl by inject()
 
     /** 1.8-style melee I-frames (10 ticks) */
     private val meleeIFrame = 500.milliseconds
@@ -53,8 +51,8 @@ class DefaultCombatManager(private val minigame: BrawlMinigame) :
 
                 val playerKit = kitService.getKitForPlayer(player) ?: return@event
 
-                val playerMeleeReach = playerKit.kitData.meleeReach
-                val playerMeleeDamage = playerKit.kitData.meleeDamage
+                val playerMeleeReach = playerKit.getMeleeReach()
+                val playerMeleeDamage = playerKit.getMeleeDamage()
 
                 player.world.livingEntities.filter { entity ->
                     if (entity == player) {
@@ -155,7 +153,7 @@ class DefaultCombatManager(private val minigame: BrawlMinigame) :
                         (damager as? Damager.DamagerLivingEntity)?.livingEntity as? Player
                     if (damagerPlayer != null) {
                         val kitKnockbackMult =
-                            kitService.getKitForPlayer(damagerPlayer)?.kitData?.knockbackMultiplier ?: 1.0
+                            kitService.getKitForPlayer(damagerPlayer)?.getKnockbackMultiplier() ?: 1.0
                         victimPlayer.doKnockback(
                             knockbackMultiplier * kitKnockbackMult,
                             damage,
@@ -257,8 +255,8 @@ class DefaultCombatManager(private val minigame: BrawlMinigame) :
         val min = Vector(boundingBox.minX, boundingBox.minY, boundingBox.minZ)
         val max = Vector(boundingBox.maxX, boundingBox.maxY, boundingBox.maxZ)
 
-        var tMin = (min.x - rayStart.x) / rayDirection.x
-        var tMax = (max.x - rayStart.x) / rayDirection.x
+        var tMin = if (rayDirection.x != 0.0) (min.x - rayStart.x) / rayDirection.x else Double.NEGATIVE_INFINITY
+        var tMax = if (rayDirection.x != 0.0) (max.x - rayStart.x) / rayDirection.x else Double.POSITIVE_INFINITY
 
         if (tMin > tMax) {
             val temp = tMin
@@ -266,8 +264,8 @@ class DefaultCombatManager(private val minigame: BrawlMinigame) :
             tMax = temp
         }
 
-        var tyMin = (min.y - rayStart.y) / rayDirection.y
-        var tyMax = (max.y - rayStart.y) / rayDirection.y
+        var tyMin = if (rayDirection.y != 0.0) (min.y - rayStart.y) / rayDirection.y else Double.NEGATIVE_INFINITY
+        var tyMax = if (rayDirection.y != 0.0) (max.y - rayStart.y) / rayDirection.y else Double.POSITIVE_INFINITY
 
         if (tyMin > tyMax) {
             val temp = tyMin
@@ -282,8 +280,8 @@ class DefaultCombatManager(private val minigame: BrawlMinigame) :
         if (tyMin > tMin) tMin = tyMin
         if (tyMax < tMax) tMax = tyMax
 
-        var tzMin = (min.z - rayStart.z) / rayDirection.z
-        var tzMax = (max.z - rayStart.z) / rayDirection.z
+        var tzMin = if (rayDirection.z != 0.0) (min.z - rayStart.z) / rayDirection.z else Double.NEGATIVE_INFINITY
+        var tzMax = if (rayDirection.z != 0.0) (max.z - rayStart.z) / rayDirection.z else Double.POSITIVE_INFINITY
 
         if (tzMin > tzMax) {
             val temp = tzMin

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/managers/CombatManager.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/managers/CombatManager.kt
@@ -2,18 +2,15 @@ package dev.betrix.superSmashMobsBrawl.minigames.managers
 
 import dev.betrix.superSmashMobsBrawl.IManageable
 import dev.betrix.superSmashMobsBrawl.Manageable
-import dev.betrix.superSmashMobsBrawl.SuperSmashMobsBrawl
 import dev.betrix.superSmashMobsBrawl.events.BrawlDamageEvent
 import dev.betrix.superSmashMobsBrawl.events.BrawlDeathEvent
 import dev.betrix.superSmashMobsBrawl.events.Damager
 import dev.betrix.superSmashMobsBrawl.events.DeathReason
 import dev.betrix.superSmashMobsBrawl.events.PlayerDamageAnalyticsEvent
-import dev.betrix.superSmashMobsBrawl.events.BrawlDamageEvent
 import dev.betrix.superSmashMobsBrawl.events.BrawlDamageType
 import dev.betrix.superSmashMobsBrawl.extensions.disguise
 import dev.betrix.superSmashMobsBrawl.extensions.doKnockback
 import dev.betrix.superSmashMobsBrawl.minigames.BrawlMinigame
-import dev.betrix.superSmashMobsBrawl.services.DataService
 import dev.betrix.superSmashMobsBrawl.services.KitService
 import gg.flyte.twilight.event.event
 import java.util.UUID

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/managers/TeamManager.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/minigames/managers/TeamManager.kt
@@ -3,20 +3,21 @@ package dev.betrix.superSmashMobsBrawl.minigames.managers
 import dev.betrix.superSmashMobsBrawl.IManageable
 import dev.betrix.superSmashMobsBrawl.Manageable
 import dev.betrix.superSmashMobsBrawl.minigames.BrawlMinigame
+import dev.betrix.superSmashMobsBrawl.minigames.MinigameTeam
 import org.bukkit.OfflinePlayer
 
 interface ITeamManager : IManageable {
-    fun findTeamOf(player: OfflinePlayer): dev.betrix.superSmashMobsBrawl.minigames.MinigameTeam?
+    fun findTeamOf(player: OfflinePlayer): MinigameTeam?
 
-    fun getTeams(): List<dev.betrix.superSmashMobsBrawl.minigames.MinigameTeam>
+    fun getTeams(): List<MinigameTeam>
 
     fun onPlayerLeave(player: OfflinePlayer) {}
 }
 
 class DefaultTeamManager(private val minigame: BrawlMinigame) : Manageable(), ITeamManager {
     private val playerToTeam =
-        mutableMapOf<java.util.UUID, dev.betrix.superSmashMobsBrawl.minigames.MinigameTeam>()
-    private var teams: List<dev.betrix.superSmashMobsBrawl.minigames.MinigameTeam> = emptyList()
+        mutableMapOf<java.util.UUID, MinigameTeam>()
+    private var teams: List<MinigameTeam> = emptyList()
 
     override fun setup() {
         playerToTeam.clear()
@@ -26,9 +27,9 @@ class DefaultTeamManager(private val minigame: BrawlMinigame) : Manageable(), IT
 
     override fun findTeamOf(
         player: OfflinePlayer
-    ): dev.betrix.superSmashMobsBrawl.minigames.MinigameTeam? {
+    ): MinigameTeam? {
         return playerToTeam[player.uniqueId]
     }
 
-    override fun getTeams(): List<dev.betrix.superSmashMobsBrawl.minigames.MinigameTeam> = teams
+    override fun getTeams(): List<MinigameTeam> = teams
 }

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/models/brawlData/KitDef.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/models/brawlData/KitDef.kt
@@ -19,6 +19,7 @@ data class KitDef(
     val passives: List<KitPassiveDef> = emptyList(),
     val abilities: List<KitAbilityDef> = emptyList(),
     val armorItems: KitArmorItemsDef? = null,
+    val meleeReach: Double = 3.0,
     @Serializable(with = MaterialSerializer::class) val displayItem: Material? = null,
     @Serializable(with = SoundSerializer::class) val selectionSound: Sound? = null,
     val userFacing: Boolean = true,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced left‑click melee attacks: hit detection is aim-based and respects each kit’s melee reach.
  - Added classic 1.8‑style knockback and brief post-hit invulnerability for smoother combat feel.
  - Enabled friendly‑fire prevention in melee: teammates can’t damage each other.
  - Kits now support a configurable melee reach, allowing distinct ranges per kit.

- Gameplay
  - Non-melee damage sources in the minigame are funneled through the new combat flow for consistent handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->