### PR TITLE
Add metadata to brawl game data

### DIFF
--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/abilities/BlockTossAbility.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/abilities/BlockTossAbility.kt
@@ -29,7 +29,8 @@ class BlockTossAbility(player: Player) : BrawlAbility("block_toss", player) {
     private val maxDamage = metadata.double("maxDamage") ?: 9.0
     private val damage = metadata.double("damage") ?: 8.0
     private val knockbackMultiplier = metadata.double("knockbackMultiplier") ?: 2.5
-    private val blockRotationStepSpeedTicks = (metadata.int("blockRotationStepSpeedTicks") ?: 4).coerceAtLeast(1)
+    private val blockRotationStepSpeedTicks =
+        (metadata.int("blockRotationStepSpeedTicks") ?: 4).coerceAtLeast(1)
 
     private val activeProjectiles = mutableListOf<BrawlProjectile>()
 

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/abilities/BlockTossAbility.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/abilities/BlockTossAbility.kt
@@ -29,6 +29,7 @@ class BlockTossAbility(player: Player) : BrawlAbility("block_toss", player) {
     private val maxDamage = metadata.double("maxDamage") ?: 9.0
     private val damage = metadata.double("damage") ?: 8.0
     private val knockbackMultiplier = metadata.double("knockbackMultiplier") ?: 2.5
+    private val blockRotationStepSpeedTicks = metadata.int("blockRotationStepSpeedTicks") ?: 4
 
     private val activeProjectiles = mutableListOf<BrawlProjectile>()
 
@@ -137,10 +138,10 @@ class BlockTossAbility(player: Player) : BrawlAbility("block_toss", player) {
         var tumbleAngleY = 0f
         var tumbleAngleX = 0f
 
-        val rotatationStepSpeedTicks = 4
+        val rotationStepSpeedTicks = blockRotationStepSpeedTicks
 
         runnables.add(
-            repeatingTask(rotatationStepSpeedTicks.toLong()) {
+            repeatingTask(rotationStepSpeedTicks.toLong()) {
                 if (!displayBlock.isValid) {
                     cancel()
                     return@repeatingTask
@@ -164,7 +165,7 @@ class BlockTossAbility(player: Player) : BrawlAbility("block_toss", player) {
 
                 displayBlock.setTransformationMatrix(transform)
                 displayBlock.interpolationDelay = 0
-                displayBlock.interpolationDuration = rotatationStepSpeedTicks
+                displayBlock.interpolationDuration = rotationStepSpeedTicks
             }
         )
 

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/abilities/BlockTossAbility.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/abilities/BlockTossAbility.kt
@@ -29,7 +29,7 @@ class BlockTossAbility(player: Player) : BrawlAbility("block_toss", player) {
     private val maxDamage = metadata.double("maxDamage") ?: 9.0
     private val damage = metadata.double("damage") ?: 8.0
     private val knockbackMultiplier = metadata.double("knockbackMultiplier") ?: 2.5
-    private val blockRotationStepSpeedTicks = metadata.int("blockRotationStepSpeedTicks") ?: 4
+    private val blockRotationStepSpeedTicks = (metadata.int("blockRotationStepSpeedTicks") ?: 4).coerceAtLeast(1)
 
     private val activeProjectiles = mutableListOf<BrawlProjectile>()
 

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/abilities/BoneExplosionAbility.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/abilities/BoneExplosionAbility.kt
@@ -13,7 +13,8 @@ class BoneExplosionAbility(player: Player) : BrawlAbility("bone_explosion", play
 
     private val explosionRadius = metadata.double("explosionRadius") ?: 7.0
     private val baseDamage = metadata.double("baseDamage") ?: 6.0
-    private val explosionKnockbackMultiplier = metadata.double("explosionKnockbackMultiplier") ?: 2.5
+    private val explosionKnockbackMultiplier =
+        metadata.double("explosionKnockbackMultiplier") ?: 2.5
     private val explosionBoneCount = metadata.int("explosionBoneCount") ?: 48
     private val explosionBoneVelocity = metadata.double("explosionBoneVelocity") ?: 0.8
 
@@ -21,7 +22,15 @@ class BoneExplosionAbility(player: Player) : BrawlAbility("bone_explosion", play
         player.location
             .clone()
             .add(0.0, 0.5, 0.5)
-            .itemEffect(explosionBoneCount, explosionBoneVelocity, Sound.ENTITY_SKELETON_HURT, 2f, 1.2f, Material.BONE, 40)
+            .itemEffect(
+                explosionBoneCount,
+                explosionBoneVelocity,
+                Sound.ENTITY_SKELETON_HURT,
+                2f,
+                1.2f,
+                Material.BONE,
+                40,
+            )
 
         val validEntities =
             player.location.getNearbyPlayers(explosionRadius).filter { it != player }

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/abilities/BoneExplosionAbility.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/abilities/BoneExplosionAbility.kt
@@ -13,12 +13,15 @@ class BoneExplosionAbility(player: Player) : BrawlAbility("bone_explosion", play
 
     private val explosionRadius = metadata.double("explosionRadius") ?: 7.0
     private val baseDamage = metadata.double("baseDamage") ?: 6.0
+    private val explosionKnockbackMultiplier = metadata.double("explosionKnockbackMultiplier") ?: 2.5
+    private val explosionBoneCount = metadata.int("explosionBoneCount") ?: 48
+    private val explosionBoneVelocity = metadata.double("explosionBoneVelocity") ?: 0.8
 
     override fun activate() {
         player.location
             .clone()
             .add(0.0, 0.5, 0.5)
-            .itemEffect(48, 0.8, Sound.ENTITY_SKELETON_HURT, 2f, 1.2f, Material.BONE, 40)
+            .itemEffect(explosionBoneCount, explosionBoneVelocity, Sound.ENTITY_SKELETON_HURT, 2f, 1.2f, Material.BONE, 40)
 
         val validEntities =
             player.location.getNearbyPlayers(explosionRadius).filter { it != player }
@@ -36,7 +39,7 @@ class BoneExplosionAbility(player: Player) : BrawlAbility("bone_explosion", play
                     entity,
                     Damager.DamagerLivingEntity(player),
                     damage,
-                    2.5,
+                    explosionKnockbackMultiplier,
                     BrawlDamageType.Explosion,
                 )
 

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/abilities/ExplodeAbility.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/abilities/ExplodeAbility.kt
@@ -29,6 +29,7 @@ class ExplodeAbility(player: Player) : BrawlAbility("explode", player) {
     private val explosionRadius = metadata.double("explosionRadius") ?: 8.0
     private val explosionKnockbackMultiplier =
         metadata.double("explosionKnockbackMultiplier") ?: 2.5
+    private val explosionVelocityStrength = metadata.double("explosionVelocityStrength") ?: 1.8
 
     override fun canActivate(sendMessage: Boolean): Boolean {
         if (isExplodeActive) {
@@ -137,7 +138,7 @@ class ExplodeAbility(player: Player) : BrawlAbility("explode", player) {
                         damageEvent.callEvent()
                     }
 
-                player.setVelocity(1.8, 0.2, 1.4, true)
+                player.setVelocity(explosionVelocityStrength, 0.2, 1.4, true)
 
                 setCooldown(currentTimeAtActivation)
             }

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/abilities/MilkSpiralAbility.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/abilities/MilkSpiralAbility.kt
@@ -18,6 +18,7 @@ class MilkSpiralAbility(player: Player) : BrawlAbility("milk_spiral", player) {
     private val damage = metadata.double("damage") ?: 5.0
     private val maxTimesHit = metadata.int("maxTimesHit") ?: 2
     private val damageCooldownMs = metadata.long("damageCooldownMs") ?: 250
+    private val particleSpiralRadius = metadata.double("particleSpiralRadius") ?: 1.5
 
     private val lastDamageTime = hashMapOf<Player, Long>()
     private val timesHit = hashMapOf<Player, Int>()
@@ -60,7 +61,6 @@ class MilkSpiralAbility(player: Player) : BrawlAbility("milk_spiral", player) {
                 val circleSecond = direction.clone().crossProduct(circleFirst).normalize()
 
                 val speed = 3
-                val radius = 1.5
                 var theta = player.ticksLived.toDouble() / speed
                 var totalAddedDistance = 0.0
 
@@ -68,11 +68,11 @@ class MilkSpiralAbility(player: Player) : BrawlAbility("milk_spiral", player) {
                     val firstParticle =
                         oldLocation
                             .clone()
-                            .add(getCirclePoint(circleFirst, circleSecond, theta, radius))
+                            .add(getCirclePoint(circleFirst, circleSecond, theta, particleSpiralRadius))
                     val secondParticle =
                         oldLocation
                             .clone()
-                            .add(getCirclePoint(circleFirst, circleSecond, theta + Math.PI, radius))
+                            .add(getCirclePoint(circleFirst, circleSecond, theta + Math.PI, particleSpiralRadius))
 
                     if (first) {
                         firstParticle.world.playSound(

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/abilities/MilkSpiralAbility.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/abilities/MilkSpiralAbility.kt
@@ -68,11 +68,25 @@ class MilkSpiralAbility(player: Player) : BrawlAbility("milk_spiral", player) {
                     val firstParticle =
                         oldLocation
                             .clone()
-                            .add(getCirclePoint(circleFirst, circleSecond, theta, particleSpiralRadius))
+                            .add(
+                                getCirclePoint(
+                                    circleFirst,
+                                    circleSecond,
+                                    theta,
+                                    particleSpiralRadius,
+                                )
+                            )
                     val secondParticle =
                         oldLocation
                             .clone()
-                            .add(getCirclePoint(circleFirst, circleSecond, theta + Math.PI, particleSpiralRadius))
+                            .add(
+                                getCirclePoint(
+                                    circleFirst,
+                                    circleSecond,
+                                    theta + Math.PI,
+                                    particleSpiralRadius,
+                                )
+                            )
 
                     if (first) {
                         firstParticle.world.playSound(

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/abilities/SulphurBombAbility.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/abilities/SulphurBombAbility.kt
@@ -23,7 +23,7 @@ class SulphurBombAbility(player: Player) : BrawlAbility("sulphur_bomb", player) 
     private val projectileDamage = metadata.double("projectileDamage") ?: 6.5
     private val projectileVelocityMultiplier =
         metadata.double("projectileVelocityMultiplier") ?: 1.55
-    private val projectileSize = metadata.double("projectileSize") ?: 0.65
+    private val projectileSize = (metadata.double("projectileSize") ?: 0.65).coerceAtLeast(0.1)
     private val projectileTrailMaxParticles = metadata.int("projectileTrailMaxParticles") ?: 8
 
     private val activeProjectiles = mutableListOf<BrawlProjectile>()

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/abilities/SulphurBombAbility.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/abilities/SulphurBombAbility.kt
@@ -21,6 +21,9 @@ class SulphurBombAbility(player: Player) : BrawlAbility("sulphur_bomb", player) 
 
     private val projectileKnockbackModifier = metadata.double("projectileKnockbackModifier") ?: 2.5
     private val projectileDamage = metadata.double("projectileDamage") ?: 6.5
+    private val projectileVelocityMultiplier = metadata.double("projectileVelocityMultiplier") ?: 1.55
+    private val projectileSize = metadata.double("projectileSize") ?: 0.65
+    private val projectileTrailMaxParticles = metadata.int("projectileTrailMaxParticles") ?: 8
 
     private val activeProjectiles = mutableListOf<BrawlProjectile>()
 
@@ -44,9 +47,9 @@ class SulphurBombAbility(player: Player) : BrawlAbility("sulphur_bomb", player) 
                     ItemStack.of(Material.COAL),
                     "abilities.sulphur_bomb.name",
                 )
-                .velocityMultiplier(1.55)
-                .projectileSize(0.65)
-                .trailEffect(Particle.SMOKE, count = 8)
+                .velocityMultiplier(projectileVelocityMultiplier)
+                .projectileSize(projectileSize)
+                .trailEffect(Particle.SMOKE, count = projectileTrailMaxParticles)
                 .impactEffect(Particle.EXPLOSION, Sound.ENTITY_GENERIC_EXPLODE)
                 .onHitEntity { entity, projectile ->
                     handleSulphurBombHit(entity, projectile)

--- a/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/abilities/SulphurBombAbility.kt
+++ b/plugin/src/main/kotlin/dev/betrix/superSmashMobsBrawl/abilities/SulphurBombAbility.kt
@@ -21,7 +21,8 @@ class SulphurBombAbility(player: Player) : BrawlAbility("sulphur_bomb", player) 
 
     private val projectileKnockbackModifier = metadata.double("projectileKnockbackModifier") ?: 2.5
     private val projectileDamage = metadata.double("projectileDamage") ?: 6.5
-    private val projectileVelocityMultiplier = metadata.double("projectileVelocityMultiplier") ?: 1.55
+    private val projectileVelocityMultiplier =
+        metadata.double("projectileVelocityMultiplier") ?: 1.55
     private val projectileSize = metadata.double("projectileSize") ?: 0.65
     private val projectileTrailMaxParticles = metadata.int("projectileTrailMaxParticles") ?: 8
 

--- a/plugin/src/main/resources/data/abilities.yml
+++ b/plugin/src/main/resources/data/abilities.yml
@@ -6,6 +6,9 @@ abilities:
     usage: right_click
     hotbarItem: iron_axe
     displayItem: coal
+    metadata:
+      projectileKnockbackModifier: 2.5
+      projectileDamage: 6.5
 
   - id: explode
     cooldown: 8.0
@@ -14,6 +17,10 @@ abilities:
     usage: right_click
     hotbarItem: iron_shovel
     displayItem: creeper_spawn_egg
+    metadata:
+      fuseTimeTicks: 30
+      explosionRadius: 8.0
+      explosionKnockbackMultiplier: 2.5
 
   - id: bone_explosion
     cooldown: 10.0
@@ -22,6 +29,9 @@ abilities:
     usage: right_click
     hotbarItem: iron_axe
     displayItem: bone
+    metadata:
+      explosionRadius: 7.0
+      baseDamage: 6.0
 
   - id: roped_arrow
     cooldown: 5.0
@@ -30,6 +40,9 @@ abilities:
     usage: left_click
     hotbarItem: bow
     displayItem: arrow
+    metadata:
+      arrowVelocityModifier: 2.4
+      arrowDamage: 6.0
 
   - id: angry_herd
     cooldown: 13.0
@@ -39,13 +52,15 @@ abilities:
     hotbarItem: iron_axe
     displayItem: cow_spawn_egg
     metadata:
-      cowsCount: 5
-      cowSpeed: 0.9
-      contactRadius: 1.2
-      durationTicks: 60
-      damagePerHit: 5.0
-      knockbackMultiplier: 1.25
-      hitCooldownTicks: 10
+      cowAmountRadius: 3
+      cowAmountHeight: 1
+      stuckTimeMs: 300
+      forceMoveTimeMs: 350
+      durationMs: 2500
+      hitboxRadius: 2.2
+      damageCooldownMs: 600
+      damage: 5.0
+      knockback: 1.25
 
   - id: milk_spiral
     cooldown: 9.0
@@ -55,14 +70,12 @@ abilities:
     hotbarItem: iron_shovel
     displayItem: milk_bucket
     metadata:
-      durationTicks: 160
-      propelTicks: 80
-      helixRadius: 1.5
-      centerSpeed: 0.9
-      playerSpeed: 1.0
+      spiralDurationMs: 3000
+      velocityDurationMs: 1800
+      hitboxRadius: 2.0
       damage: 5.0
-      maxTargets: 2
-      hitCooldownTicks: 10
+      maxTimesHit: 2
+      damageCooldownMs: 250
 
   - id: blink
     cooldown: 6.0
@@ -82,3 +95,8 @@ abilities:
     hotbarItem: iron_sword
     displayItem: grass_block
     metadata:
+      chargeTimeMs: 1200
+      maxCharge: 1.4
+      maxDamage: 9.0
+      damage: 8.0
+      knockbackMultiplier: 2.5

--- a/plugin/src/main/resources/data/abilities.yml
+++ b/plugin/src/main/resources/data/abilities.yml
@@ -9,6 +9,9 @@ abilities:
     metadata:
       projectileKnockbackModifier: 2.5
       projectileDamage: 6.5
+      projectileVelocityMultiplier: 1.55
+      projectileSize: 0.65
+      projectileTrailMaxParticles: 8
 
   - id: explode
     cooldown: 8.0
@@ -21,6 +24,7 @@ abilities:
       fuseTimeTicks: 30
       explosionRadius: 8.0
       explosionKnockbackMultiplier: 2.5
+      explosionVelocityStrength: 1.8
 
   - id: bone_explosion
     cooldown: 10.0
@@ -32,6 +36,9 @@ abilities:
     metadata:
       explosionRadius: 7.0
       baseDamage: 6.0
+      explosionKnockbackMultiplier: 2.5
+      explosionBoneCount: 48
+      explosionBoneVelocity: 0.8
 
   - id: roped_arrow
     cooldown: 5.0
@@ -76,6 +83,7 @@ abilities:
       damage: 5.0
       maxTimesHit: 2
       damageCooldownMs: 250
+      particleSpiralRadius: 1.5
 
   - id: blink
     cooldown: 6.0
@@ -100,3 +108,4 @@ abilities:
       maxDamage: 9.0
       damage: 8.0
       knockbackMultiplier: 2.5
+      blockRotationStepSpeedTicks: 4

--- a/plugin/src/main/resources/data/kits.yml
+++ b/plugin/src/main/resources/data/kits.yml
@@ -26,7 +26,7 @@ kits:
       - id: regeneration
         overrides:
           metadata:
-            regenRate: 0.4
+            healAmount: 0.4
       - id: hunger
     abilities:
       - id: sulphur_bomb
@@ -52,7 +52,7 @@ kits:
       - id: regeneration
         overrides:
           metadata:
-            regenRate: 0.25
+            healAmount: 0.25
       - id: hunger
       - id: arrow_recharge
         overrides:
@@ -81,7 +81,7 @@ kits:
       - id: regeneration
         overrides:
           metadata:
-            regenRate: 0.25
+            healAmount: 0.25
       - id: stampede
       - id: hunger
     abilities:
@@ -106,7 +106,7 @@ kits:
       - id: regeneration
         overrides:
           metadata:
-            regenRate: 0.25
+            healAmount: 0.25
       - id: hunger
     abilities:
       - id: blink

--- a/plugin/src/main/resources/data/passives.yml
+++ b/plugin/src/main/resources/data/passives.yml
@@ -1,28 +1,42 @@
 passives:
   - id: double_jump
     userFacing: false
+    metadata:
+      # Motion tuning
+      horizontalMultiplier: 0.9
+      verticalBoost: 0.9
+      allowMidairReset: false
 
   - id: hunger
     userFacing: false
+    metadata:
+      hungerRestoreDelayMs: 250
 
   - id: regeneration
     userFacing: false
+    metadata:
+      healAmount: 1.0
+      healIntervalTicks: 60
 
   - id: arrow_recharge
     displayItem: bundle
     userFacing: true
     metadata:
-      arrowIntervalTicks: 20
+      arrowHotbarSlot: 2
+      maximumArrowCount: 3
+      arrowIntervalTicks: 40
 
   - id: barrage
     displayItem: spectral_arrow
     userFacing: true
+    metadata:
+      maxCharge: 5
+      arrowDamage: 6.0
 
   - id: stampede
     displayItem: leather
     userFacing: true
     metadata:
-      maxLevel: 4
-      ticksPerLevel: 60
-      extraDamagePerLevel: 0.5
-      extraKnockbackPerLevel: 0.1
+      stackIncreaseTimeMs: 3000
+      maxStacks: 3
+      stopSprintDamage: 3


### PR DESCRIPTION
Add and standardize metadata for Brawl abilities and passives, and update kit overrides to use the new metadata keys.

---
<a href="https://cursor.com/background-agent?bcId=bc-fbbdf4c1-741e-4c27-b48e-bb9802ffe00a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fbbdf4c1-741e-4c27-b48e-bb9802ffe00a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added user-configurable parameters for many abilities: block rotation speed, bone explosion (knockback/count/velocity), explosion knockback/velocity, milk spiral radius, and sulphur bomb projectile speed/size/trail.
  - Exposed new metadata options for abilities and passives to tune charge, damage, timing, movement, and particle effects.

- Refactor
  - Consolidated and renamed configuration fields across abilities and passives.
  - Kits updated: regenRate replaced with healAmount.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->