### PR TITLE
Optimize docker-compose configuration

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -25,13 +25,11 @@
     "drizzle-orm": "^0.44.5",
     "drizzle-zod": "^0.8.3",
     "hono": "^4.9.9",
-    "postgres": "^3.4.7",
-    "redis": "^5.8.2",
     "zod": "^4.1.11"
   },
   "devDependencies": {
+    "@types/bun": "^1.2.23",
     "@types/node": "^22.18.6",
-    "@types/pg": "^8.15.5",
     "dotenv": "^17.2.2",
     "drizzle-kit": "^0.31.5",
     "tsdown": "^0.15.5",

--- a/apps/backend/src/db/index.ts
+++ b/apps/backend/src/db/index.ts
@@ -1,5 +1,5 @@
 import { env } from "@/lib/env";
-import { drizzle } from "drizzle-orm/postgres-js";
+import { drizzle } from "drizzle-orm/bun-sql";
 import * as schema from "./schema";
 
 export function getDb() {

--- a/apps/backend/src/lib/redis.ts
+++ b/apps/backend/src/lib/redis.ts
@@ -1,12 +1,6 @@
-import { createClient } from "redis";
+import { RedisClient } from "bun";
 import { env } from "./env";
 
 export async function getRedis() {
-  const redis = createClient({
-    url: env.REDIS_URL,
-  });
-
-  await redis.connect();
-
-  return redis;
+  return new RedisClient(env.REDIS_URL);
 }

--- a/apps/backend/src/lib/redis.ts
+++ b/apps/backend/src/lib/redis.ts
@@ -1,6 +1,6 @@
 import { RedisClient } from "bun";
 import { env } from "./env";
 
-export async function getRedis() {
+export function getRedis() {
   return new RedisClient(env.REDIS_URL);
 }

--- a/apps/backend/src/routers/index.ts
+++ b/apps/backend/src/routers/index.ts
@@ -1,4 +1,4 @@
-import type { RouterClient } from "@orpc/server";
+import { ORPCError, type RouterClient } from "@orpc/server";
 import { dbProvider, kvProvider, o, publicProcedure } from "../lib/orpc";
 import { pluginRouter } from "./plugin/plugin-router";
 
@@ -14,10 +14,12 @@ export const appRouter = {
         await context.db.execute("select 1");
       } catch (error) {
         console.error(error);
-        return {
-          status: "ERROR",
+
+        throw new ORPCError("INTERNAL_SERVER_ERROR", {
+          status: 500,
           message: "Database connection failed",
-        };
+          cause: error,
+        });
       }
 
       const dbCheckDuration = performance.now() - dbCheckStart;
@@ -29,10 +31,12 @@ export const appRouter = {
         await context.kv.get("test");
       } catch (error) {
         console.error(error);
-        return {
-          status: "ERROR",
+
+        throw new ORPCError("INTERNAL_SERVER_ERROR", {
+          status: 500,
           message: "KV connection failed",
-        };
+          cause: error,
+        });
       }
 
       const kvCheckDuration = performance.now() - kvCheckStart;

--- a/bun.lock
+++ b/bun.lock
@@ -24,13 +24,11 @@
         "drizzle-orm": "^0.44.5",
         "drizzle-zod": "^0.8.3",
         "hono": "^4.9.9",
-        "postgres": "^3.4.7",
-        "redis": "^5.8.2",
         "zod": "^4.1.11",
       },
       "devDependencies": {
+        "@types/bun": "^1.2.23",
         "@types/node": "^22.18.6",
-        "@types/pg": "^8.15.5",
         "dotenv": "^17.2.2",
         "drizzle-kit": "^0.31.5",
         "tsdown": "^0.15.5",
@@ -586,16 +584,6 @@
 
     "@radix-ui/rect": ["@radix-ui/rect@1.1.1", "", {}, "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="],
 
-    "@redis/bloom": ["@redis/bloom@5.8.2", "", { "peerDependencies": { "@redis/client": "^5.8.2" } }, "sha512-855DR0ChetZLarblio5eM0yLwxA9Dqq50t8StXKp5bAtLT0G+rZ+eRzzqxl37sPqQKjUudSYypz55o6nNhbz0A=="],
-
-    "@redis/client": ["@redis/client@5.8.2", "", { "dependencies": { "cluster-key-slot": "1.1.2" } }, "sha512-WtMScno3+eBpTac1Uav2zugXEoXqaU23YznwvFgkPwBQVwEHTDgOG7uEAObtZ/Nyn8SmAMbqkEubJaMOvnqdsQ=="],
-
-    "@redis/json": ["@redis/json@5.8.2", "", { "peerDependencies": { "@redis/client": "^5.8.2" } }, "sha512-uxpVfas3I0LccBX9rIfDgJ0dBrUa3+0Gc8sEwmQQH0vHi7C1Rx1Qn8Nv1QWz5bohoeIXMICFZRcyDONvum2l/w=="],
-
-    "@redis/search": ["@redis/search@5.8.2", "", { "peerDependencies": { "@redis/client": "^5.8.2" } }, "sha512-cNv7HlgayavCBXqPXgaS97DRPVWFznuzsAmmuemi2TMCx5scwLiP50TeZvUS06h/MG96YNPe6A0Zt57yayfxwA=="],
-
-    "@redis/time-series": ["@redis/time-series@5.8.2", "", { "peerDependencies": { "@redis/client": "^5.8.2" } }, "sha512-g2NlHM07fK8H4k+613NBsk3y70R2JIM2dPMSkhIjl2Z17SYvaYKdusz85d7VYOrZBWtDrHV/WD2E3vGu+zni8A=="],
-
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-beta.40", "", { "os": "android", "cpu": "arm64" }, "sha512-9Ii9phC7QU6Lb+ncMfG1Xlosq0NBB1N/4sw+EGZ3y0BBWGy02TOb5ghWZalphAKv9rn1goqo5WkBjyd2YvsLmA=="],
 
     "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.0-beta.40", "", { "os": "darwin", "cpu": "arm64" }, "sha512-5O6d0y2tBQTL+ecQY3qXIwSnF1/Zik8q7LZMKeyF+VJ9l194d0IdMhl2zUF0cqWbYHuF4Pnxplk4OhurPQ/Z9Q=="],
@@ -788,6 +776,8 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
+    "@types/bun": ["@types/bun@1.2.23", "", { "dependencies": { "bun-types": "1.2.23" } }, "sha512-le8ueOY5b6VKYf19xT3McVbXqLqmxzPXHsQT/q9JHgikJ2X22wyTW3g3ohz2ZMnp7dod6aduIiq8A14Xyimm0A=="],
+
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/node": ["@types/node@22.18.6", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-r8uszLPpeIWbNKtvWRt/DbVi5zbqZyj1PTmhRMqBMvDnaz1QpmSKujUtJLrqGZeoM8v72MfYggDceY4K1itzWQ=="],
@@ -872,7 +862,7 @@
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
-    "bun-types": ["bun-types@1.2.22", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-hwaAu8tct/Zn6Zft4U9BsZcXkYomzpHJX28ofvx7k0Zz2HNz54n1n+tDgxoWFGB4PcFvJXJQloPhaV2eP3Q6EA=="],
+    "bun-types": ["bun-types@1.2.23", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-R9f0hKAZXgFU3mlrA0YpE/fiDvwV0FT9rORApt2aQVWSuJDzZOyB5QLc0N/4HF57CS8IXJ6+L5E4W1bW6NS2Aw=="],
 
     "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
 
@@ -891,8 +881,6 @@
     "client-only": ["client-only@0.0.1", "", {}, "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
-
-    "cluster-key-slot": ["cluster-key-slot@1.1.2", "", {}, "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA=="],
 
     "color": ["color@4.2.3", "", { "dependencies": { "color-convert": "^2.0.1", "color-string": "^1.9.0" } }, "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A=="],
 
@@ -1239,8 +1227,6 @@
     "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 
     "recast": ["recast@0.23.11", "", { "dependencies": { "ast-types": "^0.16.1", "esprima": "~4.0.0", "source-map": "~0.6.1", "tiny-invariant": "^1.3.3", "tslib": "^2.0.1" } }, "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA=="],
-
-    "redis": ["redis@5.8.2", "", { "dependencies": { "@redis/bloom": "5.8.2", "@redis/client": "5.8.2", "@redis/json": "5.8.2", "@redis/search": "5.8.2", "@redis/time-series": "5.8.2" } }, "sha512-31vunZj07++Y1vcFGcnNWEf5jPoTkGARgfWI4+Tk55vdwHxhAvug8VEtW7Cx+/h47NuJTEg/JL77zAwC6E0OeA=="],
 
     "reflect-metadata": ["reflect-metadata@0.2.2", "", {}, "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="],
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,6 @@ services:
     image: postgres:18
     container_name: ssmb-postgres
     restart: unless-stopped
-    ports:
-      - "5432:5432"
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-brawl}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-brawl}
@@ -36,8 +34,6 @@ services:
     image: redis:latest
     container_name: ssmb-redis
     restart: unless-stopped
-    ports:
-      - "6379:6379"
     environment:
       REDIS_PASSWORD: ${REDIS_PASSWORD:-}
       REDIS_USER: ${REDIS_USER:-default}
@@ -82,6 +78,9 @@ services:
       context: ./plugin
       dockerfile: Dockerfile
     container_name: ssmb-minecraft
+    depends_on:
+      api:
+        condition: service_healthy
     restart: unless-stopped
     ports:
       - "${MINECRAFT_PORT:-25565}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,7 +73,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-brawl}
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-brawl}"]
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 5s
       timeout: 5s
       retries: 5
@@ -82,7 +82,7 @@ services:
     container_name: ssmb-redis
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "redis-cli", "--raw", "incr", "ping"]
+      test: ["CMD", "redis-cli", "ping"]
       interval: 5s
       timeout: 5s
       retries: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,15 +31,22 @@ services:
     command: ["bun", "run", "db:migrate"]
     restart: "no"
   redis:
-    image: docker.dragonflydb.io/dragonflydb/dragonfly
+    image: redis:latest
     container_name: ssmb-redis
     restart: unless-stopped
-    ulimits:
-      memlock: -1
+    environment:
+      REDIS_PASSWORD: ${REDIS_PASSWORD:-}
+      REDIS_USER: ${REDIS_USER:-default}
+      REDIS_DB: ${REDIS_DB:-0}
+    healthcheck:
+      test: ["CMD", "redis-cli", "--raw", "incr", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
   api:
     depends_on:
       redis:
-        condition: service_started
+        condition: service_healthy
       postgres:
         condition: service_healthy
       migrate:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,8 +21,8 @@ services:
       POLAR_SUCCESS_URL: ${POLAR_SUCCESS_URL:-http://localhost:3000/checkout/success}
       POLAR_SERVER: ${POLAR_SERVER:-sandbox}
       PLUGIN_SECRET_KEY: ${PLUGIN_SECRET_KEY:-changeme}
-      REDIS_URL: ${REDIS_URL:-redis://redis:6379/0}
-      DATABASE_URL: "postgres://${POSTGRES_USER:-brawl}:${POSTGRES_PASSWORD:-brawl}@${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-brawl}"
+      REDIS_URL: redis://redis:6379/0
+      DATABASE_URL: "postgres://postgres:${POSTGRES_PASSWORD:-brawl}@postgres:5432/postgres"
     ports:
       - "0.0.0.0:3000:3000"
     restart: unless-stopped
@@ -40,10 +40,9 @@ services:
       postgres:
         condition: service_healthy
     environment:
-      DATABASE_URL: "postgres://${POSTGRES_USER:-brawl}:${POSTGRES_PASSWORD:-brawl}@${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-brawl}"
+      DATABASE_URL: "postgres://postgres:${POSTGRES_PASSWORD:-brawl}@postgres:5432/postgres"
     command: ["bun", "run", "db:migrate"]
     restart: "no"
-    exclude_from_hc: true
   minecraft:
     build:
       context: ./plugin
@@ -65,18 +64,13 @@ services:
     restart: unless-stopped
     stdin_open: true
     tty: true
-    exclude_from_hc: true
   postgres:
     image: postgres:18
     container_name: ssmb-postgres
     volumes:
       - db_data:/var/lib/postgresql/data
     environment:
-      POSTGRES_USER: ${POSTGRES_USER:-brawl}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-brawl}
-      POSTGRES_DB: ${POSTGRES_DB:-brawl}
-      POSTGRES_HOST: ${POSTGRES_HOST:-postgres}
-      POSTGRES_PORT: ${POSTGRES_PORT:-5432}
     restart: unless-stopped
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-brawl}"]
@@ -86,10 +80,6 @@ services:
   redis:
     image: redis:8.2.1
     container_name: ssmb-redis
-    environment:
-      REDIS_PASSWORD: ${REDIS_PASSWORD:-}
-      REDIS_USER: ${REDIS_USER:-default}
-      REDIS_DB: ${REDIS_DB:-0}
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "redis-cli", "--raw", "incr", "ping"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,23 +1,36 @@
 name: super-smash-mobs-brawl
 
 services:
-  postgres:
-    image: postgres:18
-    container_name: ssmb-postgres
-    restart: unless-stopped
+  api:
+    build:
+      context: ./apps/backend
+      dockerfile: Dockerfile
+    container_name: ssmb-api
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     environment:
-      POSTGRES_USER: ${POSTGRES_USER:-brawl}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-brawl}
-      POSTGRES_DB: ${POSTGRES_DB:-brawl}
-      POSTGRES_HOST: ${POSTGRES_HOST:-postgres}
-      POSTGRES_PORT: ${POSTGRES_PORT:-5432}
+      CORS_ORIGIN: ${CORS_ORIGIN:-http://localhost:3001}
+      BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET:-changeme}
+      BETTER_AUTH_URL: ${BETTER_AUTH_URL:-http://localhost:3000}
+      POLAR_ACCESS_TOKEN: ${POLAR_ACCESS_TOKEN:-}
+      POLAR_SUCCESS_URL: ${POLAR_SUCCESS_URL:-http://localhost:3000/checkout/success}
+      POLAR_SERVER: ${POLAR_SERVER:-sandbox}
+      PLUGIN_SECRET_KEY: ${PLUGIN_SECRET_KEY:-changeme}
+      REDIS_URL: ${REDIS_URL:-redis://redis:6379/0}
+      DATABASE_URL: "postgres://${POSTGRES_USER:-brawl}:${POSTGRES_PASSWORD:-brawl}@${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-brawl}"
+    ports:
+      - "0.0.0.0:3000:3000"
+    restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-brawl}"]
+      test: ["CMD", "curl", "-f", "http://localhost:3000/api/health-check"]
       interval: 5s
       timeout: 5s
       retries: 5
-    volumes:
-      - db_data:/var/lib/postgresql/data
   migrate:
     build:
       context: ./apps/backend
@@ -30,49 +43,7 @@ services:
       DATABASE_URL: "postgres://${POSTGRES_USER:-brawl}:${POSTGRES_PASSWORD:-brawl}@${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-brawl}"
     command: ["bun", "run", "db:migrate"]
     restart: "no"
-  redis:
-    image: redis:latest
-    container_name: ssmb-redis
-    restart: unless-stopped
-    environment:
-      REDIS_PASSWORD: ${REDIS_PASSWORD:-}
-      REDIS_USER: ${REDIS_USER:-default}
-      REDIS_DB: ${REDIS_DB:-0}
-    healthcheck:
-      test: ["CMD", "redis-cli", "--raw", "incr", "ping"]
-      interval: 5s
-      timeout: 5s
-      retries: 5
-  api:
-    depends_on:
-      redis:
-        condition: service_healthy
-      postgres:
-        condition: service_healthy
-      migrate:
-        condition: service_completed_successfully
-    build:
-      context: ./apps/backend
-      dockerfile: Dockerfile
-    container_name: ssmb-api
-    restart: unless-stopped
-    ports:
-      - "3000:3000"
-    environment:
-      CORS_ORIGIN: ${CORS_ORIGIN:-http://localhost:3001}
-      BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET:-changeme}
-      BETTER_AUTH_URL: ${BETTER_AUTH_URL:-http://localhost:3000}
-      POLAR_ACCESS_TOKEN: ${POLAR_ACCESS_TOKEN:-}
-      POLAR_SUCCESS_URL: ${POLAR_SUCCESS_URL:-http://localhost:3000/checkout/success}
-      POLAR_SERVER: ${POLAR_SERVER:-sandbox}
-      PLUGIN_SECRET_KEY: ${PLUGIN_SECRET_KEY:-changeme}
-      REDIS_URL: ${REDIS_URL:-redis://redis:6379/0}
-      DATABASE_URL: "postgres://${POSTGRES_USER:-brawl}:${POSTGRES_PASSWORD:-brawl}@${POSTGRES_HOST:-postgres}:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-brawl}"
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3000/api/health-check"]
-      interval: 5s
-      timeout: 5s
-      retries: 5
+    exclude_from_hc: true
   minecraft:
     build:
       context: ./plugin
@@ -81,9 +52,6 @@ services:
     depends_on:
       api:
         condition: service_healthy
-    restart: unless-stopped
-    ports:
-      - "${MINECRAFT_PORT:-25565}"
     environment:
       MEMORY_SIZE: ${MINECRAFT_MEMORY:-2G}
       ONLINE_MODE: ${ONLINE_MODE:-false}
@@ -92,8 +60,42 @@ services:
       AXIOM_DATASET_NAME: ${AXIOM_DATASET_NAME:-super-smash-mobs-brawl}
       BASE_API_URL: ${BASE_API_URL:-http://api:3000/api}
       API_SECRET_KEY: ${API_SECRET_KEY:-changeme}
+    ports:
+      - "0.0.0.0:${MINECRAFT_PORT:-25565}:${MINECRAFT_PORT:-25565}"
+    restart: unless-stopped
     stdin_open: true
     tty: true
+    exclude_from_hc: true
+  postgres:
+    image: postgres:18
+    container_name: ssmb-postgres
+    volumes:
+      - db_data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-brawl}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-brawl}
+      POSTGRES_DB: ${POSTGRES_DB:-brawl}
+      POSTGRES_HOST: ${POSTGRES_HOST:-postgres}
+      POSTGRES_PORT: ${POSTGRES_PORT:-5432}
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-brawl}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+  redis:
+    image: redis:8.2.1
+    container_name: ssmb-redis
+    environment:
+      REDIS_PASSWORD: ${REDIS_PASSWORD:-}
+      REDIS_USER: ${REDIS_USER:-default}
+      REDIS_DB: ${REDIS_DB:-0}
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "redis-cli", "--raw", "incr", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
 volumes:
   db_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,22 +31,15 @@ services:
     command: ["bun", "run", "db:migrate"]
     restart: "no"
   redis:
-    image: redis:latest
+    image: docker.dragonflydb.io/dragonflydb/dragonfly
     container_name: ssmb-redis
     restart: unless-stopped
-    environment:
-      REDIS_PASSWORD: ${REDIS_PASSWORD:-}
-      REDIS_USER: ${REDIS_USER:-default}
-      REDIS_DB: ${REDIS_DB:-0}
-    healthcheck:
-      test: ["CMD", "redis-cli", "--raw", "incr", "ping"]
-      interval: 5s
-      timeout: 5s
-      retries: 5
+    ulimits:
+      memlock: -1
   api:
     depends_on:
       redis:
-        condition: service_healthy
+        condition: service_started
       postgres:
         condition: service_healthy
       migrate:


### PR DESCRIPTION
Remove unnecessary port exposures for internal services and add a health-checked dependency for Minecraft on the API.

---
<a href="https://cursor.com/background-agent?bcId=bc-837893ff-7798-47b0-a1f1-2ad0d7f71901"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-837893ff-7798-47b0-a1f1-2ad0d7f71901"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched database and Redis integrations to Bun-native drivers.
  * Standardized error handling to throw structured server errors instead of returning raw payloads.

* **Chores**
  * Cleaned up dependencies: removed Postgres/Redis runtime packages and related types; added Bun type definitions.
  * Reworked docker-compose: separated api/migrate/minecraft services, added Postgres/Redis services with healthchecks, fixed env URLs, exposed API on port 3000, added restart policies and persistent volume.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->